### PR TITLE
Store clusterizations as `factors`

### DIFF
--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -127,7 +127,7 @@ setClass(
     }
 
     for (name in names(object@clustersCoex)) {
-      if (substring(name, 1L, 3L) != "CL_") {
+      if (!startsWith(name, "CL_")) {
         stop("The clusterization name '", name, "' does not start",
              " with 'CL_' as per conventions")
       }
@@ -159,8 +159,13 @@ setClass(
     }
 
     for (name in colnames(object@metaCells)) {
-      if (substring(name, 1L, 3L) != "CL_") {
-        next # not a clusterization name
+      if (!startsWith(name, "CL_")) {
+        # not a clusterization name
+        next
+      }
+      if (!inherits(object@metaCells[[name]], "factor")) {
+        # ensure the clusters are factors
+        object@metaCells[[name]] <- factor(object@metaCells[[name]])
       }
       if (!name %in% names(object@clustersCoex)) {
         stop("The clusterization name '", name, "' does not have",
@@ -340,7 +345,7 @@ getCOTANSlots <- function(from) {
 
   hasClusters <- !is_empty(from@clusters) && !all(is.na(from@clusters))
   if (hasClusters) {
-    metaCells <- setColumnInDF(metaCells, from@clusters,
+    metaCells <- setColumnInDF(metaCells, factor(from@clusters),
                                "CL_clusters", colnames(from@raw))
   }
 
@@ -511,7 +516,8 @@ getScCOTANSlots <- function(from) {
   }
 
   if (!is_empty(from@metaCells[[clName]])) {
-    clusters <- set_names(from@metaCells[[clName]], rownames(from@metaCells))
+    clusters <- from@metaCells[[clName]]
+    clusters <- set_names(levels(clusters)[clusters], rownames(from@metaCells))
   } else {
     # ensure non-empty vector
     clusters <- set_names(rep(NA, ncol(from@raw)), colnames(from@raw))

--- a/R/COTAN-estimators.R
+++ b/R/COTAN-estimators.R
@@ -124,8 +124,6 @@ setMethod(
 #'
 #' @returns `estimateDispersionBisection()` returns the updated `COTAN` object
 #'
-#' @importFrom rlang set_names
-#'
 #' @importFrom parallel mclapply
 #' @importFrom parallel splitIndices
 #'
@@ -250,7 +248,6 @@ setMethod(
 #' @returns `estimateNuBisection()` returns the updated `COTAN` object
 #'
 #' @importFrom rlang is_empty
-#' @importFrom rlang set_names
 #'
 #' @importFrom parallel mclapply
 #' @importFrom parallel splitIndices

--- a/R/COTAN-modifiers.R
+++ b/R/COTAN-modifiers.R
@@ -296,7 +296,7 @@ setMethod(
            clName, "'.")
     }
 
-    objCOTAN@metaCells <- setColumnInDF(objCOTAN@metaCells, clusters,
+    objCOTAN@metaCells <- setColumnInDF(objCOTAN@metaCells, factor(clusters),
                                         internalName, getCells(objCOTAN))
 
     # this add a new entry in the list for the new name!

--- a/R/DEAOnClusters.R
+++ b/R/DEAOnClusters.R
@@ -30,6 +30,8 @@ DEAOnClusters <- function(objCOTAN, clusters = NULL) {
   if (is_empty(clusters)) {
     # pick the last clusterization
     clusters <- getClusterizationData(objCOTAN)[["clusters"]]
+  } else if (!inherits(clusters, "factor")) {
+    clusters <- factor(clusters)
   }
 
   assert_that(length(clusters) == getNumCells(objCOTAN),

--- a/R/GDI-plot.R
+++ b/R/GDI-plot.R
@@ -7,8 +7,8 @@
 #' @param objCOTAN a `COTAN` object
 #' @param genes a named `list` of genes to label. Each array will have different
 #'   color.
-#' @param cond a string corresponding to the condition/sample (it is used only
-#'   for the title).
+#' @param condition a string corresponding to the condition/sample (it is used
+#'   only for the title).
 #' @param statType type of statistic to be used. Default is "S": Pearson's
 #'   chi-squared test statistics. "G" is G-test statistics
 #' @param GDIThreshold the threshold level that discriminates uniform clusters.

--- a/R/UMAP-plot.R
+++ b/R/UMAP-plot.R
@@ -66,7 +66,7 @@ UMAPPlot <- function(df, clusters = NULL, elements = NULL, title = "") {
   labelled <- colors != "none"
 
   # assign a different color to each cluster
-  for (cl in unique(clusters)) {
+  for (cl in levels(factor(clusters))) {
     selec <- !labelled & clusters == cl
     if (any(selec)) {
       colors[selec] <- cl

--- a/R/cellsUniformClustering.R
+++ b/R/cellsUniformClustering.R
@@ -68,7 +68,7 @@ seuratClustering <- function(rawData, cond, iter, minNumClusters,
     # the number of residual cells decrease and to stop clustering
     # if the algorithm gives too many singletons.
     if ((minNumClusters <
-           length(levels(factor(srat[["seurat_clusters", drop = TRUE]])))) ||
+           nlevels(factor(srat[["seurat_clusters", drop = TRUE]]))) ||
         (resolution > initialResolution + 1.5)) {
       break
     }
@@ -303,6 +303,8 @@ cellsUniformClustering <- function(objCOTAN,  GDIThreshold = 1.4,
     outputClusters[unclusteredCells] <- "not_clustered"
     outputClusters <- set_names(outputClusters, getCells(objCOTAN))
   }
+
+  outputClusters <- factor(outputClusters)
 
   if (saveObj) {
     clusterizationName <-

--- a/R/clustersSummaryPlot.R
+++ b/R/clustersSummaryPlot.R
@@ -194,11 +194,13 @@ clustersTreePlot <- function(objCOTAN, kCuts,
   # pick last if no name was given
   clName <- getClusterizationName(objCOTAN, clName = clName)
   c(clusters, coexDF) %<-% getClusterizationData(objCOTAN, clName = clName)
+  assert_that(inherits(clusters, "factor"),
+              msg = "Internal error - clusters must be factors")
 
-  if (kCuts > length(unique(clusters))) {
+  if (kCuts > nlevels(clusters)) {
     logThis("The number of cuts must be not more than the number of clusters",
             logLevel = 1L)
-    kCuts <- length(unique(clusters))
+    kCuts <- nlevels(clusters)
   }
 
   colVector <- getColorsVector(kCuts)

--- a/R/heatmap-plot.R
+++ b/R/heatmap-plot.R
@@ -82,7 +82,7 @@ heatmapPlot <- function(genesLists, sets, conditions, dir,
                               geneSubsetRow = allGenes)
     pValue <- as.data.frame(pValue)
 
-    pValue[["g2"]] <- as.vector(rownames(pValue))
+    pValue[["g2"]] <- rownames(pValue)
     dfTempVal <- pivot_longer(pValue, cols = seq_along(colnames(pValue)) - 1L,
                               names_to = "g1", values_to = "pValue")
 
@@ -91,7 +91,7 @@ heatmapPlot <- function(genesLists, sets, conditions, dir,
     coex <- coex[getGenes(obj) %in% allGenes, getGenes(obj) %in% colGenes]
     coex <- as.data.frame(coex)
 
-    coex[["g2"]] <- as.vector(rownames(coex))
+    coex[["g2"]] <- rownames(coex)
     dfTempCoex <- pivot_longer(coex, cols = seq_along(colnames(pValue)) - 1L,
                                names_to = "g1", values_to = "coex")
 
@@ -335,7 +335,7 @@ cellsHeatmapPlot <- function(objCOTAN, cells = NULL, clusters = NULL) {
   # if clustering is needed
   if (!is_empty(clusters)) {
     # identifier for each cluster
-    clustersTags <- unique(clusters)
+    clustersTags <- levels(factor(clusters))
 
     # size of each cluster
     clustersList <- toClustersList(clusters)

--- a/R/mergeUniformCellsClusters.R
+++ b/R/mergeUniformCellsClusters.R
@@ -101,6 +101,8 @@ mergeUniformCellsClusters <- function(objCOTAN,
     outputClusters <- getClusterizationData(objCOTAN)[["clusters"]]
   }
 
+  outputClusters <- factorToVector(outputClusters)
+
   cond <- getMetadataElement(objCOTAN, datasetTags()[["cond"]])
 
   outDirCond <- file.path(outDir, cond)
@@ -139,7 +141,6 @@ mergeUniformCellsClusters <- function(objCOTAN,
     }
 
     hcNorm <- hclust(coexDist, method = hclustMethod)
-    #plot(hcNorm)
 
     dend <- as.dendrogram(hcNorm)
 
@@ -231,6 +232,8 @@ mergeUniformCellsClusters <- function(objCOTAN,
     colnames(coexDF)   <- clTagsMap[colnames(coexDF)]
     colnames(pValueDF) <- clTagsMap[colnames(pValueDF)]
   }
+
+  outputClusters <- factor(outputClusters)
 
   logThis("Merging cells' uniform clustering: DONE", logLevel = 2L)
 

--- a/tests/testthat/test-AllClasses.R
+++ b/tests/testthat/test-AllClasses.R
@@ -62,7 +62,8 @@ test_that("'scCOTAN' converters",{
   expect_null(obj_sc@yes_yes)
   expect_length(obj_sc@clusters, ncol(obj_sc@raw))
   if (!all(is.na(obj_sc@clusters))) {
-    expect_equal(obj_sc@clusters, getClusterizationData(obj)[["clusters"]])
+    expect_equal(obj_sc@clusters,
+                 factorToVector(getClusterizationData(obj)[["clusters"]]))
     expect_equal(obj_sc@cluster_data, getClusterizationData(obj)[["coex"]])
   } else {
     expect_length(obj_sc@cluster_data, 0)

--- a/tests/testthat/test-COTAN-modifiers.R
+++ b/tests/testthat/test-COTAN-modifiers.R
@@ -111,7 +111,7 @@ test_that("Managed clusterizations", {
 
   obj <- COTAN(raw = raw)
 
-  clusters <- set_names(rep(c(1, 2), 10), getCells(obj))
+  clusters <- factor(set_names(rep(c(1, 2), 10), getCells(obj)))
   obj <- addClusterization(obj, clName = "Test",
                            clusters = clusters)
 
@@ -134,7 +134,7 @@ test_that("Managed clusterizations", {
                "CL_Test")
   expect_equal(getClusterizationData(obj)[["coex"]], coexDF)
 
-  clusters2 = set_names(rep(c("2", "1"), 10), getCells(obj))
+  clusters2 = factor(set_names(rep(c("2", "1"), 10), getCells(obj)))
   coexDF2 <- set_names(
     as.data.frame(atan(getNormalizedData(obj)[, 1:2] - 0.7) / pi * 2),
     c("1", "2"))

--- a/tests/testthat/test-cellsUniformClustering.R
+++ b/tests/testthat/test-cellsUniformClustering.R
@@ -21,7 +21,7 @@ test_that("Cell Uniform Clustering", {
 
   gc()
 
-  expect_equal(length(levels(factor(clusters))), 4)
+  expect_equal(nlevels(clusters), 4)
 
   obj <- addClusterization(obj, clName = "clusters", clusters = clusters)
 

--- a/tests/testthat/test-mergeUniformCellsClusters.R
+++ b/tests/testthat/test-mergeUniformCellsClusters.R
@@ -12,7 +12,7 @@ test_that("Merge Uniform Cells Clusters", {
 
   obj <- proceedToCoex(obj, cores = 12, saveObj = FALSE)
 
-  clusters <- readRDS(file.path(getwd(), "clusters1.RDS"))
+  clusters <- factor(readRDS(file.path(getwd(), "clusters1.RDS")))
   genes.names.test <- readRDS(file.path(getwd(), "genes.names.test.RDS"))
 
   obj <- addClusterization(obj, clName = "clusters", clusters = clusters)
@@ -21,10 +21,10 @@ test_that("Merge Uniform Cells Clusters", {
 
   obj <- addClusterizationCoex(obj, clName = "clusters", coexDF = coexDF)
 
-  expect_equal(colnames(coexDF), sort(unique(clusters)))
+  expect_setequal(colnames(coexDF), levels(clusters))
   expect_equal(rownames(coexDF), getGenes(obj))
 
-  expect_equal(colnames(pValDF), sort(unique(clusters)))
+  expect_setequal(colnames(pValDF), levels(clusters))
   expect_equal(rownames(pValDF), getGenes(obj))
 
   coexDF_exp <- readRDS(file.path(getwd(), "coex.test.cluster1.RDS"))
@@ -38,7 +38,7 @@ test_that("Merge Uniform Cells Clusters", {
   deltaExpression <- clustersDeltaExpression(obj)
 
   expect_equal(rownames(deltaExpression), getGenes(obj))
-  expect_equal(colnames(deltaExpression), sort(unique(clusters)))
+  expect_setequal(colnames(deltaExpression), levels(clusters))
 
   #primaryMarkers <- getGenes(objCOTAN)[sample(getNumGenes(objCOTAN), 10)]
   groupMarkers <- list(G1 = c("g-000010", "g-000020", "g-000030"),
@@ -62,14 +62,14 @@ test_that("Merge Uniform Cells Clusters", {
                               distance = "cosine", hclustMethod = "ward.D2",
                               saveObj = TRUE, outDir = tm)
 
-  expect_lt(length(unique(mergedClusters)), length(unique(clusters)))
+  expect_lt(nlevels(mergedClusters), nlevels(clusters))
   expect_setequal(mergedClusters, colnames(mergedCoexDF))
   expect_setequal(colnames(mergedCoexDF), colnames(mergedPValueDF))
 
   #cluster_data <- readRDS(file.path(getwd(), "cluster_data_merged.RDS"))
   #expect_equal(mergedClusters[genes.names.test], cluster_data)
 
-  for (cl in unique(mergedClusters)) {
+  for (cl in levels(mergedClusters)) {
     cellsToDrop <- names(clusters)[mergedClusters != cl]
 
     clObj <- dropGenesCells(obj, cells = cellsToDrop)

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -76,7 +76,7 @@ test_that("Clusterizations manipulations", {
   clusterM1 <- mergeClusters(clusters, names = as.roman(c(5, 1)),
                              mergedName = "I'V")
 
-  expect_true("I'V" %in% levels(clusterM1)[[1L]])
+  expect_equal(levels(clusterM1)[[1L]], "I'V")
   expect_equal(table(clusterM1)[[1L]], sum(table(clusters)[c(1, 5)]))
 
   clusterM2 <-


### PR DESCRIPTION
- All functions returning a clusterization now return an object of type `factor`.

- Clusterizations are now stored as `factor` in the metadataCell `data.frame`

- Added factorToVector() function to enable smooth transitions from `factor` to `character` arrays without loss of names

- Update tests to the new type