### PR TITLE
Added initialResolution parameter to `cellsUniformClustering()`

### DIFF
--- a/R/mergeUniformCellsClusters.R
+++ b/R/mergeUniformCellsClusters.R
@@ -77,6 +77,7 @@
 #' ##
 #'
 #' splitList <- cellsUniformClustering(objCOTAN, cores = 12,
+#'                                     initialResolution = 0.8,
 #'                                     GDIThreshold = 1.5, saveObj = FALSE)
 #'
 #' clusters <- splitList[["clusters"]]

--- a/man/UniformClusters.Rd
+++ b/man/UniformClusters.Rd
@@ -23,6 +23,7 @@ cellsUniformClustering(
   GDIThreshold = 1.4,
   cores = 1L,
   maxIterations = 25L,
+  initialResolution = 0.8,
   distance = "cosine",
   hclustMethod = "ward.D2",
   saveObj = TRUE,
@@ -71,8 +72,12 @@ here to speed up the process (default is \code{NULL})}
 
 \item{cores}{number cores used}
 
-\item{maxIterations}{Max number of re-clustering iterations. It defaults to
-\eqn{25}.}
+\item{maxIterations}{max number of re-clustering iterations. It defaults to
+\eqn{25}}
+
+\item{initialResolution}{a number indicating how refined are the clusters
+before checking for \strong{uniformity}. It defaults to \eqn{0.8}, the same as
+\code{\link[Seurat:FindClusters]{Seurat::FindClusters()}}}
 
 \item{distance}{type of distance to use (default is \code{"cosine"}, \code{"euclidean"}
 and the others from \code{\link[parallelDist:parDist]{parallelDist::parDist()}} are also available)}
@@ -132,7 +137,7 @@ given \code{GDIThreshold}
 
 \code{cellsUniformClustering()} finds a \strong{Uniform} \emph{clusterizations} by
 means of the \code{GDI}. Once a preliminary \emph{clusterization} is obtained from
-the \code{Seurat} package methods, each \emph{cluster} is checked for \strong{uniformity}
+the \code{Seurat-package} methods, each \emph{cluster} is checked for \strong{uniformity}
 via the function \code{\link[=checkClusterUniformity]{checkClusterUniformity()}}. Once all \emph{clusters} are
 checked, all cells from the \strong{non-uniform} clusters are pooled together
 for another iteration of the entire process, until all \emph{clusters} are
@@ -178,6 +183,7 @@ plot(gdiPlot)
 ##
 
 splitList <- cellsUniformClustering(objCOTAN, cores = 12,
+                                    initialResolution = 0.8,
                                     GDIThreshold = 1.5, saveObj = FALSE)
 
 clusters <- splitList[["clusters"]]

--- a/tests/outputTestDatasetCreation.R
+++ b/tests/outputTestDatasetCreation.R
@@ -43,8 +43,10 @@ outputTestDatasetCreation <- function(testsDir = file.path("tests",
   saveRDS(pval.test, file.path(testsDir, "pval.test.RDS"))
 
   GDIThreshold <- 1.5
+  initialResolution <- 0.8
 
   clusters <- cellsUniformClustering(obj, GDIThreshold = GDIThreshold,
+                                     initialResolution =   initialResolution,
                                      cores = 12L, saveObj = FALSE)[["clusters"]]
   saveRDS(clusters, file.path(testsDir, "clusters1.RDS"))
 

--- a/tests/testthat/test-cellsUniformClustering.R
+++ b/tests/testthat/test-cellsUniformClustering.R
@@ -15,9 +15,10 @@ test_that("Cell Uniform Clustering", {
                        cores = 12L, saveObj = TRUE, outDir = tm)
 
   GDIThreshold <- 1.5
-
+  initialResolution <- 0.8
   suppressWarnings({
     clusters <- cellsUniformClustering(obj, GDIThreshold = GDIThreshold,
+                                       initialResolution = initialResolution,
                                        cores = 12L, saveObj = TRUE,
                                        outDir = tm)[["clusters"]]
   })
@@ -55,7 +56,7 @@ test_that("Cell Uniform Clustering", {
   expect_identical(sum(clMarkersDF[["IsMarker"]]), 0L)
 
   topGenesNum <- as.integer(substring(clMarkersDF[["Gene"]], 6L))
-  highPos <- (1L:80L) %in% c(1L:10L, 21L:30L, 51L:60L, 71L:80L)
+  highPos <- (1L:80L) %in% c(11L:20L, 31L:40L, 41L:50L, 61L:70L)
   expect_gt(min(topGenesNum[ highPos]), 480L)
   expect_lt(max(topGenesNum[!highPos]), 241L)
 

--- a/vignettes/Guided_tutorial_v2.Rmd
+++ b/vignettes/Guided_tutorial_v2.Rmd
@@ -413,6 +413,7 @@ the genes expression is not dependent on the cell in consideration.
 
 ```{r eval=FALSE, include=TRUE}
 fineClusters <- cellsUniformClustering(obj, GDIThreshold = 1.4,
+                                       initialResolution = 0.8,
                                        cores = 10L, saveObj = TRUE,
                                        outDir = outDir)[["clusters"]]
 obj <- addClusterization(obj, clName = "FineClusters", clusters = fineClusters)


### PR DESCRIPTION
Allowed users to specify the initial resolution used in the calls to `Seurat::FindClusters()` method. It now uses the same default as the this method (0.8) instead of (0.5)