### PR TITLE
Added average floor to `logFoldChangeOnClusters()`

### DIFF
--- a/R/DEAOnClusters.R
+++ b/R/DEAOnClusters.R
@@ -151,6 +151,9 @@ pValueFromDEA <- function(coexDF, numCells, method = "none") {
 #'   significant!
 #' @param clusters A *clusterization* to use. If given it will take precedence
 #'   on the one indicated by `clName`
+#' @param floorLambdaFraction Indicates the lower bound to the average count sums
+#'   inside or outside the cluster for each gene as fraction of the relevant
+#'   `lambda` parameter. Default is `5%`
 #'
 #' @return `logFoldChangeOnClusters()` returns the log-expression-change
 #'   `data.frame` for the genes in each *cluster*
@@ -165,7 +168,8 @@ pValueFromDEA <- function(coexDF, numCells, method = "none") {
 #'
 #' @rdname HandlingClusterizations
 #'
-logFoldChangeOnClusters <- function(objCOTAN, clName = "", clusters = NULL) {
+logFoldChangeOnClusters <- function(objCOTAN, clName = "", clusters = NULL,
+                                    floorLambdaFraction = 0.05) {
   logThis("Log Fold Change Analysis - START", logLevel = 2L)
 
   # picks up the last clusterization if none was given
@@ -178,6 +182,12 @@ logFoldChangeOnClusters <- function(objCOTAN, clName = "", clusters = NULL) {
   numCells <- getNumCells(objCOTAN)
 
   normData <- getNormalizedData(objCOTAN)
+
+  if (is_empty(getLambda(objCOTAN))) {
+    stop("lambda must not be empty, estimate it")
+  }
+
+  floorAverage <- getLambda(objCOTAN) * floorLambdaFraction
 
   lfcDF <- data.frame()
 
@@ -195,16 +205,17 @@ logFoldChangeOnClusters <- function(objCOTAN, clName = "", clusters = NULL) {
     }
 
     # log of average expression inside/outside the cluster
-    logAverageIn  <-
-      log10(pmax(rowSums(normData[,  cellsIn, drop = FALSE]), 1L) /
-              max(numCellsIn,  1L))
-    logAverageOut <-
-      log10(pmax(rowSums(normData[, !cellsIn, drop = FALSE]), 1L) /
-              max(numCellsOut, 1L))
+    averageIn  <-
+      rowSums(normData[,  cellsIn, drop = FALSE]) / max(numCellsIn,  1L)
+    averageOut <-
+      rowSums(normData[, !cellsIn, drop = FALSE]) / max(numCellsOut, 1L)
+
+    logAverageIn  <- log10(pmax(averageIn,  floorAverage))
+    logAverageOut <- log10(pmax(averageOut, floorAverage))
 
     lfc <- logAverageIn - logAverageOut
 
-    rm(logAverageIn, logAverageOut)
+    rm(averageIn, averageOut, logAverageIn, logAverageOut)
     gc()
 
     lfcDF <- setColumnInDF(lfcDF, colToSet = lfc,

--- a/man/HandlingClusterizations.Rd
+++ b/man/HandlingClusterizations.Rd
@@ -65,7 +65,12 @@ DEAOnClusters(objCOTAN, clName = "", clusters = NULL)
 
 pValueFromDEA(coexDF, numCells, method = "none")
 
-logFoldChangeOnClusters(objCOTAN, clName = "", clusters = NULL)
+logFoldChangeOnClusters(
+  objCOTAN,
+  clName = "",
+  clusters = NULL,
+  floorLambdaFraction = 0.05
+)
 
 UMAPPlot(df, clusters = NULL, elements = NULL, title = "")
 
@@ -156,6 +161,10 @@ data losses}
 
 \item{method}{\emph{p-value} multi-test adjustment method. Defaults to
 \code{"bonferroni"}; use \code{"none"} for no adjustment}
+
+\item{floorLambdaFraction}{Indicates the lower bound to the average count sums
+inside or outside the cluster for each gene as fraction of the relevant
+\code{lambda} parameter. Default is \verb{5\%}}
 
 \item{df}{the \code{data.frame} to plot. It must have a row names containing the
 given elements}

--- a/tests/testthat/test-mergeUniformCellsClusters.R
+++ b/tests/testthat/test-mergeUniformCellsClusters.R
@@ -27,13 +27,15 @@ test_that("Merge Uniform Cells Clusters", {
   expect_setequal(colnames(coexDF), levels(clusters))
   expect_identical(rownames(coexDF), getGenes(obj))
 
-  lfcDF <- logFoldChangeOnClusters(obj, clusters = clusters)
+  lfcDF <- logFoldChangeOnClusters(obj, clusters = clusters,
+                                   floorLambdaFraction = 0.01)
 
   expect_setequal(colnames(lfcDF), clusters)
   expect_identical(rownames(lfcDF), getGenes(obj))
   expect_gte(min(colSums(lfcDF > 0.0)), 280L)
   expect_lte(max(colSums(lfcDF > 0.0)), 302L)
-  expect_lt(max(abs(colMeans(lfcDF))), 0.06)
+  expect_lt(max(colMeans(lfcDF)),  0.00)
+  expect_gt(min(colMeans(lfcDF)), -0.06)
 
   method <- "bonferroni"
 


### PR DESCRIPTION
Added a new argument to `logFoldChangeOnClusters()` in order to define a lower bound to the ritz density inside/outside of a cluster for each gene, based on the relevant `lambda` calculated on the entire dataset. It defaults to 5%.