### PR TITLE
Better checks about handling of the clusterizations and the conditions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: COTAN
 Type: Package
 Title: COexpression Tables ANalysis 
-Version: 2.3.5
+Version: 2.3.6
 Authors@R: c(
   person("Galfrè", "Silvia Giulia",email = "silvia.galfre@di.unipi.it", role=c("aut","cre"),comment = c(ORCID = "0000-0002-2770-0344")),
   person("Morandin","Francesco", email = "francesco.morandin@unipr.it", role = "aut",comment = c(ORCID = "0000-0002-2022-2300")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 ## COTAN 2.3.5
 
+Made checks when adding a clusterization or condition more strict
+
+## COTAN 2.3.5
+
 Increased reliability of clustering functions by improved error handling and 
 by allowing retry runs on estimators functions
 

--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -159,17 +159,20 @@ setClass(
     }
 
     for (name in colnames(object@metaCells)) {
-      if (!startsWith(name, "CL_")) {
-        # not a clusterization name
-        next
-      }
-      if (!inherits(object@metaCells[[name]], "factor")) {
-        # ensure the clusters are factors
-        object@metaCells[[name]] <- factor(object@metaCells[[name]])
-      }
-      if (!name %in% names(object@clustersCoex)) {
-        stop("The clusterization name '", name, "' does not have",
-             " an element in the 'clusterCoex' list")
+      if (startsWith(name, "CL_")) {
+        if (!inherits(object@metaCells[[name]], "factor")) {
+          # ensure the clusters are factors
+          object@metaCells[[name]] <- factor(object@metaCells[[name]])
+        }
+        if (!name %in% names(object@clustersCoex)) {
+          stop("The clusterization name '", name, "' does not have",
+               " an element in the 'clusterCoex' list")
+        }
+      } else if (startsWith(name, "COND_")) {
+        if (!inherits(object@metaCells[[name]], "factor")) {
+          # ensure the clusters are factors
+          object@metaCells[[name]] <- factor(object@metaCells[[name]])
+        }
       }
     }
 

--- a/R/COTAN-getters.R
+++ b/R/COTAN-getters.R
@@ -1143,11 +1143,12 @@ setMethod(
     assert_that(!isEmptyName(internalName),
                 msg = "No clusterizations are present in the 'COTAN' object")
 
-    clusters <- set_names(getMetadataCells(objCOTAN)[[internalName]],
-                          getCells(objCOTAN))
+    clusters <- factor(set_names(getMetadataCells(objCOTAN)[[internalName]],
+                                 getCells(objCOTAN)))
 
-    return(list("clusters" = clusters,
-                "coex" = getClustersCoex(objCOTAN)[[internalName]]))
+    coexDF <- getClustersCoex(objCOTAN)[[internalName]]
+
+    return(list("clusters" = clusters, "coex" = coexDF))
   }
 )
 

--- a/R/COTAN-getters.R
+++ b/R/COTAN-getters.R
@@ -1233,8 +1233,9 @@ NULL
 #' data("test.dataset")
 #' objCOTAN <- COTAN(raw = test.dataset)
 #'
-#' genre <- rep(c("F", "M"), getNumCells(objCOTAN) / 2)
-#' objCOTAN <- addCondition(objCOTAN, condName = "Genre", conditions = genre)
+#' cellLine <- rep(c("A", "B"), getNumCells(objCOTAN) / 2)
+#' names(cellLine) <- getCells(objCOTAN)
+#' objCOTAN <- addCondition(objCOTAN, condName = "Line", conditions = cellLine)
 #'
 #' ##objCOTAN <- dropCondition(objCOTAN, "Genre")
 #'

--- a/R/clustersMarkersHeatmapPlot.R
+++ b/R/clustersMarkersHeatmapPlot.R
@@ -81,7 +81,7 @@ clustersMarkersHeatmapPlot <- function(objCOTAN, groupMarkers,
   scoreDF <- geneSetEnrichment(groupMarkers = groupMarkers,
                                clustersCoex = expressionCl)
 
-  scoreDFT <- t(scoreDF[, 1L:(ncol(scoreDF) - 2L)])
+  scoreDFT <- t(scoreDF[, 1L:(ncol(scoreDF) - 2L), drop = FALSE])
   dend <- clustersTreePlot(objCOTAN, kCuts = kCuts, clName = clName)[["dend"]]
 
   dend <- set(dend = dend, "branches_lwd", 2L)

--- a/R/clustersSummaryPlot.R
+++ b/R/clustersSummaryPlot.R
@@ -233,8 +233,10 @@ clustersTreePlot <- function(objCOTAN,
                              distance = NULL,
                              hclustMethod = "ward.D2") {
   # pick last if no name was given
-  clName <- getClusterizationName(objCOTAN, clName = clName)
-  clusters <- getClusters(objCOTAN, clName = clName)
+  # picks up the last clusterization if none was given
+  c(clName, clusters) %<-%
+    normalizeNameAndLabels(objCOTAN, name = clName,
+                           labels = clusters, isCond = FALSE)
   assert_that(inherits(clusters, "factor"),
               msg = "Internal error - clusters must be factors")
 

--- a/man/HandlingConditions.Rd
+++ b/man/HandlingConditions.Rd
@@ -101,8 +101,9 @@ object, by removing the corresponding column in the \code{metaCells}
 data("test.dataset")
 objCOTAN <- COTAN(raw = test.dataset)
 
-genre <- rep(c("F", "M"), getNumCells(objCOTAN) / 2)
-objCOTAN <- addCondition(objCOTAN, condName = "Genre", conditions = genre)
+cellLine <- rep(c("A", "B"), getNumCells(objCOTAN) / 2)
+names(cellLine) <- getCells(objCOTAN)
+objCOTAN <- addCondition(objCOTAN, condName = "Line", conditions = cellLine)
 
 ##objCOTAN <- dropCondition(objCOTAN, "Genre")
 

--- a/tests/testthat/test-AllClasses.R
+++ b/tests/testthat/test-AllClasses.R
@@ -42,7 +42,8 @@ test_that("'scCOTAN' converters", {
     c(1L, 2L))
 
   obj <- addClusterization(obj, clName = "clusters",
-                           clusters = rep(colnames(coexDF), 10L),
+                           clusters = set_names(rep(colnames(coexDF), 10L),
+                                                colnames(raw)),
                            coexDF = coexDF)
 
   # coerce 'COTAN' -> 'scCOTAN'

--- a/tests/testthat/test-COTAN-getters.R
+++ b/tests/testthat/test-COTAN-getters.R
@@ -15,14 +15,18 @@ test_that("COTAN getters", {
   obj <- calculateCoex(obj, actOnCells = TRUE,  optimizeForSpeed = TRUE)
 
   obj <- addClusterization(obj, clName = "Test",
-                           clusters = rep(c(1L, 2L), 10L))
+                           clusters = set_names(rep(c(1L, 2L), 10L),
+                                                colnames(raw)))
   obj <- addClusterization(obj, clName = "Test2",
-                           clusters = rep(c(2L, 1L), 10L))
+                           clusters = set_names(rep(c(2L, 1L), 10L),
+                                                colnames(raw)))
 
   obj <- addCondition(obj, condName = "Test",
-                      conditions = rep(c("F", "M"), 10L))
+                      conditions = set_names(rep(c("F", "M"), 10L),
+                                             colnames(raw)))
   obj <- addCondition(obj, condName = "Test", override = TRUE,
-                      conditions = c(rep(c("F", "M"), 9L), "M", "F"))
+                      conditions = set_names(c(rep(c("F", "M"), 9L), "M", "F"),
+                                             colnames(raw)))
 
   metaInfo <- c("V", "10X", "Test", "20", "TRUE", "TRUE",
                 paste0(10.0 / 55.0), paste0(0L))

--- a/tests/testthat/test-COTAN-modifiers.R
+++ b/tests/testthat/test-COTAN-modifiers.R
@@ -192,13 +192,17 @@ test_that("Managed clusterizations and conditions", {
   expect_error(getClusters(obj, clName = "Test"))
   expect_error(getCondition(obj, condName = "Test"))
 
-  # empyt name clusterization/consition
+  # empty name clusterization/condition
   expect_error(addClusterization(obj, clName = "", clusters = rep(0L, 20L)))
   expect_error(addCondition(obj, condName = "", conditions = rep(0L, 20L)))
 
+  # no names in clusterization
+  expect_error(addClusterization(obj, clName = "Test", clusters = rep(0L, 20L)))
+  expect_error(addCondition(obj, condName = "Cond", conditions = rep(0L, 20L)))
+
   # already existing clusterization
   expect_error(addClusterization(obj, clName = "Test2",
-                                 clusters = rep(0L, 20L)))
+                                 clusters = clusters2))
 
   # wrong clusters/conditions size
   expect_error(addClusterization(obj, clName = "Test", clusters = rep(0L, 17L)))


### PR DESCRIPTION
Before it was possible to insert a misaligned clusterization or condition or Coex data-frame,
causing unexpected and obscure errors