### PR TITLE
Now it is possible to properly resume clusters' merges

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 ## COTAN 2.3.6
 
+Changed default `GDI` threshold to 1.43
+
+Added new input to `mergeUniformCellsClusters()` to allow proper resume of
+interrupted merges
+
 Added possibility to query whether the `COEX` matrix is available in a `COTAN`
 object
 

--- a/R/GDI-plot.R
+++ b/R/GDI-plot.R
@@ -12,7 +12,7 @@
 #' @param statType type of statistic to be used. Default is "S": Pearson's
 #'   chi-squared test statistics. "G" is G-test statistics
 #' @param GDIThreshold the threshold level that discriminates uniform clusters.
-#'   It defaults to \eqn{1.4}
+#'   It defaults to \eqn{1.43}
 #' @param GDIIn when the `GDI` data frame was already calculated, it can be put
 #'   here to speed up the process (default is `NULL`)
 #'
@@ -42,7 +42,7 @@
 #' @rdname UniformClusters
 #'
 GDIPlot <- function(objCOTAN, genes, condition = "",
-                    statType = "S", GDIThreshold = 1.4,
+                    statType = "S", GDIThreshold = 1.43,
                     GDIIn = NULL) {
   logThis("GDI plot", logLevel = 2L)
 

--- a/R/checkClusterUniformity.R
+++ b/R/checkClusterUniformity.R
@@ -10,7 +10,7 @@
 #' @param cluster the tag of the *cluster*
 #' @param cells the cells belonging to the *cluster*
 #' @param GDIThreshold the threshold level that discriminates uniform
-#'   *clusters*. It defaults to \eqn{1.4}
+#'   *clusters*. It defaults to \eqn{1.43}
 #' @param cores number of cores used
 #' @param saveObj Boolean flag; when `TRUE` saves intermediate analyses and
 #'   plots to file(s)
@@ -38,7 +38,7 @@
 #'
 
 checkClusterUniformity <- function(objCOTAN, cluster, cells,
-                                   GDIThreshold = 1.4, cores = 1L,
+                                   GDIThreshold = 1.43, cores = 1L,
                                    saveObj = TRUE, outDir = ".") {
 
   cellsToDrop <- getCells(objCOTAN)[!getCells(objCOTAN) %in% cells]

--- a/R/clustersSummaryPlot.R
+++ b/R/clustersSummaryPlot.R
@@ -189,6 +189,9 @@ clustersSummaryPlot <- function(objCOTAN, clName = "", clusters = NULL,
 #' @param clName The name of the *clusterization*. If not given the last
 #'   available *clusterization* will be returned, as it is probably the most
 #'   significant!
+#' @param clusters A *clusterization* to use. If given it will take precedence
+#'   on the one indicated by `clName` that will only indicate the relevant
+#'   column name in the returned `data.frame`
 #' @param useDEA Boolean indicating whether to use the *DEA* to define the
 #'   distance; alternatively it will use the average *Zero-One* counts, that is
 #'   faster but less precise.
@@ -229,6 +232,7 @@ clustersSummaryPlot <- function(objCOTAN, clName = "", clusters = NULL,
 clustersTreePlot <- function(objCOTAN,
                              kCuts,
                              clName = "",
+                             clusters = NULL,
                              useDEA = TRUE,
                              distance = NULL,
                              hclustMethod = "ward.D2") {

--- a/man/HandlingClusterizations.Rd
+++ b/man/HandlingClusterizations.Rd
@@ -117,6 +117,7 @@ clustersTreePlot(
   objCOTAN,
   kCuts,
   clName = "",
+  clusters = NULL,
   useDEA = TRUE,
   distance = NULL,
   hclustMethod = "ward.D2"

--- a/man/UniformClusters.Rd
+++ b/man/UniformClusters.Rd
@@ -14,13 +14,13 @@ GDIPlot(
   genes,
   condition = "",
   statType = "S",
-  GDIThreshold = 1.4,
+  GDIThreshold = 1.43,
   GDIIn = NULL
 )
 
 cellsUniformClustering(
   objCOTAN,
-  GDIThreshold = 1.4,
+  GDIThreshold = 1.43,
   cores = 1L,
   maxIterations = 25L,
   initialClusters = NULL,
@@ -36,7 +36,7 @@ checkClusterUniformity(
   objCOTAN,
   cluster,
   cells,
-  GDIThreshold = 1.4,
+  GDIThreshold = 1.43,
   cores = 1L,
   saveObj = TRUE,
   outDir = "."
@@ -45,8 +45,9 @@ checkClusterUniformity(
 mergeUniformCellsClusters(
   objCOTAN,
   clusters = NULL,
-  GDIThreshold = 1.4,
+  GDIThreshold = 1.43,
   batchSize = 10L,
+  notMergeable = NULL,
   cores = 1L,
   useDEA = TRUE,
   distance = NULL,
@@ -68,7 +69,7 @@ only for the title).}
 chi-squared test statistics. "G" is G-test statistics}
 
 \item{GDIThreshold}{the threshold level that discriminates uniform clusters.
-It defaults to \eqn{1.4}}
+It defaults to \eqn{1.43}}
 
 \item{GDIIn}{when the \code{GDI} data frame was already calculated, it can be put
 here to speed up the process (default is \code{NULL})}
@@ -113,6 +114,10 @@ significant!}
 
 \item{batchSize}{Number pairs to test in a single round. If none of them
 succeeds the merge stops}
+
+\item{notMergeable}{An array of names of merged clusters that are already
+known for not being uniform. Useful to restart the \emph{merging} process after
+an interruption.}
 }
 \value{
 \code{GDIPlot()} returns a \code{ggplot2} object
@@ -196,13 +201,13 @@ plot(gdiPlot)
 
 splitList <- cellsUniformClustering(objCOTAN, cores = 12,
                                     initialResolution = 0.8,
-                                    GDIThreshold = 1.5, saveObj = FALSE)
+                                    GDIThreshold = 1.46, saveObj = FALSE)
 
 clusters <- splitList[["clusters"]]
 
 firstCluster <- getCells(objCOTAN)[clusters \%in\% clusters[[1L]]]
 checkClusterUniformity(objCOTAN,
-                       GDIThreshold = 1.5,
+                       GDIThreshold = 1.46,
                        cluster = clusters[[1L]],
                        cells = firstCluster,
                        cores = 12L,
@@ -219,7 +224,7 @@ objCOTAN <- addClusterizationCoex(objCOTAN,
 identical(reorderClusterization(objCOTAN)[["clusters"]], clusters)
 
 mergedList <- mergeUniformCellsClusters(objCOTAN,
-                                        GDIThreshold = 1.5,
+                                        GDIThreshold = 1.46,
                                         batchSize = 5L,
                                         clusters = clusters,
                                         cores = 12L,

--- a/tests/outputTestDatasetCreation.R
+++ b/tests/outputTestDatasetCreation.R
@@ -42,7 +42,7 @@ outputTestDatasetCreation <- function(testsDir = file.path("tests",
   pval.test <- calculatePValue(obj, geneSubsetCol = genes.names.test)
   saveRDS(pval.test, file.path(testsDir, "pval.test.RDS"))
 
-  GDIThreshold <- 1.5
+  GDIThreshold <- 1.46
   initialResolution <- 0.8
 
   clusters <- cellsUniformClustering(obj, GDIThreshold = GDIThreshold,

--- a/tests/testthat/test-cellsUniformClustering.R
+++ b/tests/testthat/test-cellsUniformClustering.R
@@ -14,14 +14,17 @@ test_that("Cell Uniform Clustering", {
   obj <- proceedToCoex(obj, calcCoex = FALSE,
                        cores = 12L, saveObj = TRUE, outDir = tm)
 
-  GDIThreshold <- 1.5
+  GDIThreshold <- 1.46
   initialResolution <- 0.8
   suppressWarnings({
-    clusters <- cellsUniformClustering(obj, GDIThreshold = GDIThreshold,
+  clusters <- cellsUniformClustering(obj, GDIThreshold = GDIThreshold,
                                        initialResolution = initialResolution,
                                        cores = 12L, saveObj = TRUE,
                                        outDir = tm)[["clusters"]]
   })
+
+  expect_true(file.exists(file.path(tm, "test", "reclustering_1",
+                                    "partial_clusterization.csv")))
 
   gc()
 

--- a/tests/testthat/test-mergeUniformCellsClusters.R
+++ b/tests/testthat/test-mergeUniformCellsClusters.R
@@ -54,7 +54,7 @@ test_that("Merge Uniform Cells Clusters", {
   expect_equal(coexDF[genes.names.test, ], coexDF_exp, tolerance = 1.0e-12)
   expect_equal(pValDF[genes.names.test, ], pValDF_exp, tolerance = 1.0e-12)
 
-  GDIThreshold <- 1.5
+  GDIThreshold <- 1.46
 
   deltaExpression <- clustersDeltaExpression(obj)
 
@@ -81,6 +81,11 @@ test_that("Merge Uniform Cells Clusters", {
                               GDIThreshold = GDIThreshold,
                               distance = "cosine", hclustMethod = "ward.D2",
                               saveObj = TRUE, outDir = tm)
+
+  expect_true(file.exists(file.path(tm, "test", "leafs_merge",
+                                    "merge_clusterization_1.csv")))
+  expect_true(file.exists(file.path(tm, "test", "leafs_merge",
+                                    "non_mergeable_clusters_1.csv")))
 
   expect_lt(nlevels(mergedClusters), nlevels(clusters))
   expect_setequal(colnames(mergedCoexDF), mergedClusters)

--- a/vignettes/Guided_tutorial_v2.Rmd
+++ b/vignettes/Guided_tutorial_v2.Rmd
@@ -284,7 +284,7 @@ head(quantP)
 
 The next function can either plot the `GDI` for the dataset directly or
 use the pre-computed dataframe.
-It marks a `1.5` threshold (in red) and
+It marks a `1.43` threshold (in red) and
 the two highest quantiles (in blue) by default.
 We can also specify some gene sets (three in this case) that
 we want to label explicitly in the `GDI` plot.
@@ -301,7 +301,8 @@ genesList <- list(
 # needs to be recalculated after the changes in nu/dispersion above
 #obj <- calculateCoex(obj, actOnCells = FALSE)
 
-GDIPlot(obj, GDIIn = quantP, cond = cond, genes = genesList)
+GDIPlot(obj, GDIIn = quantP, cond = cond,
+        genes = genesList, GDIThreshold = 1.43)
 ```
 
 The percentage of cells expressing the gene in the third column of this
@@ -411,7 +412,7 @@ satisfies the null hypothesis of the `COTAN` model:
 the genes expression is not dependent on the cell in consideration.
 
 ```{r eval=FALSE, include=TRUE}
-fineClusters <- cellsUniformClustering(obj, GDIThreshold = 1.4,
+fineClusters <- cellsUniformClustering(obj, GDIThreshold = 1.43,
                                        initialResolution = 0.8,
                                        cores = 10L, saveObj = TRUE,
                                        outDir = outDir)[["clusters"]]
@@ -427,7 +428,7 @@ obj <- addClusterizationCoex(obj, clName = "FineClusters",
 
 ```{r eval=FALSE, include=TRUE}
 c(mergedClusters, coexDF) %<-%
-  mergeUniformCellsClusters(obj, GDIThreshold = 1.4, cores = 10L,
+  mergeUniformCellsClusters(obj, GDIThreshold = 1.43, cores = 10L,
                             saveObj = TRUE, outDir = outDir)
 obj <- addClusterization(obj, clName = "MergedClusters",
                          clusters = mergedClusters, coexDF = coexDF)


### PR DESCRIPTION
Now `COTAN` saves and can use the list of failed merge pairings

Also changed default GDI threshold to 1.43 from the too strict 1.40

Fixed issue with function `clustersTreePlot()`