### PR TITLE
Added dumping of uniformity check results in clustering functions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 ## COTAN 2.3.6
 
+Now clustering functions dump the `GDI` check results for all clusters
+
 Changed default `GDI` threshold to 1.43
 
 Added new input to `mergeUniformCellsClusters()` to allow proper resume of
@@ -10,9 +12,7 @@ object
 
 ## COTAN 2.3.5
 
-Made checks when adding a clusterization or condition more strict
-
-## COTAN 2.3.5
+Made checks more strict when adding a *clusterization* or *condition*
 
 Increased reliability of clustering functions by improved error handling and 
 by allowing retry runs on estimators functions

--- a/R/checkClusterUniformity.R
+++ b/R/checkClusterUniformity.R
@@ -20,7 +20,7 @@
 #' @returns `checkClusterUniformity` returns a list with:
 #'   * `"isUniform"`: a flag indicating whether the *cluster* is **uniform**
 #'   * `"fractionAbove"`: the percentage of genes with `GDI` above the threshold
-#'   * `"1stPercentile"`: the quantile associated to the highest percentile
+#'   * `"firstPercentile"`: the quantile associated to the highest percentile
 #'
 #' @importFrom utils head
 #'
@@ -118,5 +118,5 @@ checkClusterUniformity <- function(objCOTAN, cluster, cells,
 
   return(list("isUniform" = clusterIsUniform,
               "fractionAbove" = percAboveThr,
-              "1stPercentile" = quantAboveThr))
+              "firstPercentile" = quantAboveThr[[1L]]))
 }

--- a/man/UniformClusters.Rd
+++ b/man/UniformClusters.Rd
@@ -132,7 +132,7 @@ an interruption.}
 \itemize{
 \item \code{"isUniform"}: a flag indicating whether the \emph{cluster} is \strong{uniform}
 \item \code{"fractionAbove"}: the percentage of genes with \code{GDI} above the threshold
-\item \code{"1stPercentile"}: the quantile associated to the highest percentile
+\item \code{"firstPercentile"}: the quantile associated to the highest percentile
 }
 
 a \code{list} with:

--- a/tests/testthat/test-cellsUniformClustering.R
+++ b/tests/testthat/test-cellsUniformClustering.R
@@ -17,14 +17,17 @@ test_that("Cell Uniform Clustering", {
   GDIThreshold <- 1.46
   initialResolution <- 0.8
   suppressWarnings({
-  clusters <- cellsUniformClustering(obj, GDIThreshold = GDIThreshold,
+    clusters <- cellsUniformClustering(obj, GDIThreshold = GDIThreshold,
                                        initialResolution = initialResolution,
                                        cores = 12L, saveObj = TRUE,
                                        outDir = tm)[["clusters"]]
   })
 
-  expect_true(file.exists(file.path(tm, "test", "reclustering_1",
-                                    "partial_clusterization.csv")))
+  expect_true(file.exists(file.path(tm, "test", "reclustering",
+                                    "partial_clusterization_1.csv")))
+  expect_true(file.exists(file.path(tm, "test", "reclustering",
+                                    "all_check_results_1.csv")))
+  expect_true(file.exists(file.path(tm, "test", "split_check_results.csv")))
 
   gc()
 

--- a/tests/testthat/test-mergeUniformCellsClusters.R
+++ b/tests/testthat/test-mergeUniformCellsClusters.R
@@ -86,6 +86,9 @@ test_that("Merge Uniform Cells Clusters", {
                                     "merge_clusterization_1.csv")))
   expect_true(file.exists(file.path(tm, "test", "leafs_merge",
                                     "non_mergeable_clusters_1.csv")))
+  expect_true(file.exists(file.path(tm, "test", "leafs_merge",
+                                    "all_check_results_1.csv")))
+  expect_true(file.exists(file.path(tm, "test", "merge_check_results.csv")))
 
   expect_lt(nlevels(mergedClusters), nlevels(clusters))
   expect_setequal(colnames(mergedCoexDF), mergedClusters)


### PR DESCRIPTION
From now on it will be possible to recover the results of the `checkUniformCluster()` from dumped .csv files