### PR TITLE
Speed-up of paramenters estimates (dispersion and nu)

### DIFF
--- a/R/DEAOnClusters.R
+++ b/R/DEAOnClusters.R
@@ -201,6 +201,8 @@ logFoldChangeOnClusters <- function(objCOTAN, clName = "", clusters = NULL,
 
   floorAverage <- getLambda(objCOTAN) * floorLambdaFraction
 
+  allSums <- rowSums(normData)
+
   lfcDF <- data.frame()
 
   for (cl in names(clustersList)) {
@@ -217,10 +219,10 @@ logFoldChangeOnClusters <- function(objCOTAN, clName = "", clusters = NULL,
     }
 
     # log of average expression inside/outside the cluster
-    averageIn  <-
-      rowSums(normData[,  cellsIn, drop = FALSE]) / max(numCellsIn,  1L)
-    averageOut <-
-      rowSums(normData[, !cellsIn, drop = FALSE]) / max(numCellsOut, 1L)
+    inSums <- rowSums(normData[,  cellsIn, drop = FALSE])
+
+    averageIn  <- inSums             / max(numCellsIn,  1L)
+    averageOut <- (allSums - inSums) / max(numCellsOut, 1L)
 
     logAverageIn  <- log10(pmax(averageIn,  floorAverage))
     logAverageOut <- log10(pmax(averageOut, floorAverage))

--- a/R/cellsUniformClustering.R
+++ b/R/cellsUniformClustering.R
@@ -445,10 +445,10 @@ cellsUniformClustering <- function(objCOTAN,
     outputClusters <- set_names(outputClusters, getCells(objCOTAN))
 
     allCheckResults <- allCheckResults[clTags, , drop = FALSE]
-    allCheckResults <- allCheckResults[clTagsMap[clTags], , drop = FALSE]
+    rownames(allCheckResults) <- clTagsMap[clTags]
     if (any(unclusteredCells)) {
       errorCheckResults[["size"]] <- length(unclusteredCells)
-      allCheckResults <- rbind(allCheckResults, "-1" <- errorCheckResults)
+      allCheckResults <- rbind(allCheckResults, "-1" = errorCheckResults)
     }
   }
 
@@ -459,7 +459,7 @@ cellsUniformClustering <- function(objCOTAN,
                return(NULL)
                })
 
-  c(outputClusters, outputCoexDF) %<-% tryCatch(
+  c(outputClusters, outputCoexDF, permMap) %<-% tryCatch(
     reorderClusterization(objCOTAN, clusters = outputClusters,
                           coexDF = outputCoexDF, reverse = FALSE,
                           keepMinusOne = TRUE, useDEA = useDEA,
@@ -468,6 +468,7 @@ cellsUniformClustering <- function(objCOTAN,
       logThis(paste("Calling reorderClusterization", err), logLevel = 0L)
       return(list(outputClusters, outputCoexDF))
     })
+  rownames(allCheckResults) <- permMap[rownames(allCheckResults)]
 
   outputList <- list("clusters" = factor(outputClusters), "coex" = outputCoexDF)
 

--- a/R/mergeUniformCellsClusters.R
+++ b/R/mergeUniformCellsClusters.R
@@ -370,7 +370,7 @@ mergeUniformCellsClusters <- function(objCOTAN,
     outputClusters <- set_names(outputClusters, getCells(objCOTAN))
 
     allCheckResults <- allCheckResults[clTags, , drop = FALSE]
-    allCheckResults <- allCheckResults[clTagsMap[clTags], , drop = FALSE]
+    rownames(allCheckResults) <- clTagsMap[clTags]
   }
 
   outputCoexDF <-
@@ -380,7 +380,7 @@ mergeUniformCellsClusters <- function(objCOTAN,
                return(NULL)
              })
 
-  c(outputClusters, outputCoexDF) %<-% tryCatch(
+  c(outputClusters, outputCoexDF, permMap) %<-% tryCatch(
     reorderClusterization(objCOTAN, clusters = outputClusters,
                           coexDF = outputCoexDF, reverse = FALSE,
                           keepMinusOne = FALSE, useDEA = useDEA,
@@ -389,6 +389,7 @@ mergeUniformCellsClusters <- function(objCOTAN,
       logThis(paste("Calling reorderClusterization", err), logLevel = 0L)
       return(list(outputClusters, outputCoexDF))
     })
+  rownames(allCheckResults) <- permMap[rownames(allCheckResults)]
 
   if (isTRUE(saveObj)) tryCatch({
     outFile <- file.path(outDirCond, "merge_check_results.csv")

--- a/R/mergeUniformCellsClusters.R
+++ b/R/mergeUniformCellsClusters.R
@@ -16,7 +16,7 @@
 #' @param GDIThreshold the threshold level that discriminates uniform clusters.
 #'   It defaults to \eqn{1.43}
 #' @param batchSize Number pairs to test in a single round. If none of them
-#'   succeeds the merge stops
+#'   succeeds the merge stops. Defaults to \eqn{2 (\#cl)^{2/3}}
 #' @param notMergeable An array of names of merged clusters that are already
 #'   known for not being uniform. Useful to restart the *merging* process after
 #'   an interruption.
@@ -139,7 +139,7 @@
 mergeUniformCellsClusters <- function(objCOTAN,
                                       clusters = NULL,
                                       GDIThreshold = 1.43,
-                                      batchSize = 10L,
+                                      batchSize = 0L,
                                       notMergeable = NULL,
                                       cores = 1L,
                                       optimizeForSpeed = TRUE,
@@ -162,6 +162,13 @@ mergeUniformCellsClusters <- function(objCOTAN,
   }
 
   outputClusters <- factorToVector(outputClusters)
+
+  if (batchSize == 0L) {
+    # default is twice the (2/3) power of the number of clusters
+    numCl <- length(unique(outputClusters))
+    batchSize <- as.integer(ceiling(2.0 * numCl^(2.0 / 3.0)))
+    rm(numCl)
+  }
 
   cond <- getMetadataElement(objCOTAN, datasetTags()[["cond"]])
 

--- a/R/numericUtilities.R
+++ b/R/numericUtilities.R
@@ -145,6 +145,8 @@ dispersionBisection <-
 #'
 #' @returns the dispersion values
 #'
+#' @importFrom Rfast rowsums
+#'
 #' @rdname NumericUtilities
 #'
 parallelDispersionBisection <-
@@ -179,7 +181,7 @@ parallelDispersionBisection <-
     # we look for two dispersion values where the first leads to a
     # diffZeros negative and the second positive
     disps1 <- rep(0.0, length(sumZeros))
-    diffs1 <- rowSums(funProbZero(disps1, mu)) - sumZeros
+    diffs1 <- rowsums(funProbZero(disps1, mu)) - sumZeros
     if (all(abs(diffs1) <= threshold)) {
       output[goodPos] <- disps1
       return(output)
@@ -191,7 +193,7 @@ parallelDispersionBisection <-
     runPos <- rep(TRUE, length(diffs1))
     iter <- 1L
     repeat {
-      diffs2[runPos] <- (rowSums(funProbZero(disps2[runPos],
+      diffs2[runPos] <- (rowsums(funProbZero(disps2[runPos],
                                              mu[runPos, , drop = FALSE])) -
                            sumZeros[runPos])
 
@@ -221,7 +223,7 @@ parallelDispersionBisection <-
     repeat {
       disps[runPos] <- (disps1[runPos] + disps2[runPos]) / 2.0
 
-      diffs[runPos] <- (rowSums(funProbZero(disps[runPos],
+      diffs[runPos] <- (rowsums(funProbZero(disps[runPos],
                                             mu[runPos, , drop = FALSE])) -
                           sumZeros[runPos])
 
@@ -355,6 +357,8 @@ nuBisection <-
 #'
 #' @importFrom assertthat assert_that
 #'
+#' @importFrom Rfast colsums
+#'
 #' @rdname NumericUtilities
 #'
 parallelNuBisection <-
@@ -386,7 +390,7 @@ parallelNuBisection <-
     # diffZeros negative and the second positive
     nus1 <- initialGuess[goodPos]
 
-    diffs1 <- colSums(funProbZero(dispersion, lambda %o% nus1)) - sumZeros
+    diffs1 <- colsums(funProbZero(dispersion, lambda %o% nus1)) - sumZeros
     if (all(abs(diffs1) <= threshold)) {
       output[goodPos] <- nus1
       return(output)
@@ -399,7 +403,7 @@ parallelNuBisection <-
     runPos <- rep(TRUE, length(diffs1))
     iter <- 1L
     repeat {
-      diffs2[runPos] <- (colSums(funProbZero(dispersion,
+      diffs2[runPos] <- (colsums(funProbZero(dispersion,
                                              lambda %o% nus2[runPos])) -
                            sumZeros[runPos])
 
@@ -432,7 +436,7 @@ parallelNuBisection <-
     repeat {
       nus[runPos] <- (nus1[runPos] + nus2[runPos]) / 2.0
 
-      diffs[runPos] <- (colSums(funProbZero(dispersion,
+      diffs[runPos] <- (colsums(funProbZero(dispersion,
                                             lambda %o% nus[runPos])) -
                           sumZeros[runPos])
 

--- a/R/reorderClusterization.R
+++ b/R/reorderClusterization.R
@@ -25,6 +25,7 @@
 #' @returns `reorderClusterization()` returns a `list` with 2 elements:
 #'   * `"clusters"` the newly reordered cluster labels array
 #'   * `"coex"` the associated `COEX` `data.frame`
+#'   * `"permMap"` the reordering mapping
 #'
 #' @export
 #'
@@ -113,5 +114,6 @@ reorderClusterization <- function(objCOTAN,
     }
   }
 
-  return(list("clusters" = factor(outputClusters), "coex" = outputCoexDF))
+  return(list("clusters" = factor(outputClusters),
+              "coex" = outputCoexDF, "permMap" = clMap))
 }

--- a/man/HandlingClusterizations.Rd
+++ b/man/HandlingClusterizations.Rd
@@ -334,6 +334,7 @@ score
 \itemize{
 \item \code{"clusters"} the newly reordered cluster labels array
 \item \code{"coex"} the associated \code{COEX} \code{data.frame}
+\item \code{"permMap"} the reordering mapping
 }
 }
 \description{

--- a/man/UniformClusters.Rd
+++ b/man/UniformClusters.Rd
@@ -50,7 +50,7 @@ mergeUniformCellsClusters(
   objCOTAN,
   clusters = NULL,
   GDIThreshold = 1.43,
-  batchSize = 10L,
+  batchSize = 0L,
   notMergeable = NULL,
   cores = 1L,
   optimizeForSpeed = TRUE,
@@ -128,7 +128,7 @@ available \emph{clusterization} will be used, as it is probably the most
 significant!}
 
 \item{batchSize}{Number pairs to test in a single round. If none of them
-succeeds the merge stops}
+succeeds the merge stops. Defaults to \eqn{2 (\#cl)^{2/3}}}
 
 \item{notMergeable}{An array of names of merged clusters that are already
 known for not being uniform. Useful to restart the \emph{merging} process after

--- a/tests/testthat/test-cellsUniformClustering.R
+++ b/tests/testthat/test-cellsUniformClustering.R
@@ -56,7 +56,7 @@ test_that("Cell Uniform Clustering", {
   clusters2 <- factor(clusters, levels = c("-1", levels(clusters)))
   clusters2[1L:50L] <- "-1"
   coexDF2 <- DEAOnClusters(obj, clusters = clusters2)
-  c(rClusters2, rCoexDF2) %<-%
+  c(rClusters2, rCoexDF2, permMap2) %<-%
     reorderClusterization(obj, reverse = TRUE, keepMinusOne = TRUE,
                           clusters = clusters2, coexDF = coexDF2)
 
@@ -65,10 +65,12 @@ test_that("Cell Uniform Clustering", {
   expect_identical(rClusters2 == "-1", clusters2 == "-1")
   # this is an happenstance
   expect_identical(colnames(rCoexDF2), rev(levels(rClusters2)))
+  expect_identical(permMap2, set_names(paste0(c(2, 1, 4, 3, -1)),
+                                       paste0(c(1:4, -1))))
 
   clusters3 <- factor(clusters, levels = c(levels(clusters), "-1"))
   clusters3[51L:100L] <- "-1"
-  c(clusters3, coexDF3) %<-%
+  c(clusters3, coexDF3, permMap3) %<-%
     reorderClusterization(obj, useDEA = FALSE,
                           reverse = FALSE, keepMinusOne = TRUE,
                           clusters = clusters3, coexDF = coexDF2)
@@ -78,6 +80,8 @@ test_that("Cell Uniform Clustering", {
   expect_identical((clusters3 == "-1")[51:150], (clusters2 == "-1")[1:100])
   # this is an happenstance
   expect_identical(colnames(coexDF3)[-5L], levels(clusters3)[-1L])
+  expect_identical(permMap3, set_names(paste0(c(2, 3, 1, 4, -1)),
+                                       paste0(c(1:4, -1))))
 
   exactClusters <- set_names(rep(1L:2L, each = 600L), nm = getCells(obj))
 

--- a/tests/testthat/test-mergeUniformCellsClusters.R
+++ b/tests/testthat/test-mergeUniformCellsClusters.R
@@ -103,7 +103,7 @@ test_that("Merge Uniform Cells Clusters", {
   expect_setequal(colnames(mergedLfcDF), mergedClusters)
   expect_identical(rownames(mergedLfcDF), getGenes(obj))
   # with 2 clusters the changes are symmetric
-  expect_identical(mergedLfcDF[[1L]], -mergedLfcDF[[2L]])
+  expect_equal(mergedLfcDF[[1L]], -mergedLfcDF[[2L]], tolerance = 1.0e-12)
 
   for (cl in levels(mergedClusters)) {
     cellsToDrop <- names(clusters)[mergedClusters != cl]

--- a/tests/testthat/test-mergeUniformCellsClusters.R
+++ b/tests/testthat/test-mergeUniformCellsClusters.R
@@ -95,7 +95,7 @@ test_that("Merge Uniform Cells Clusters", {
   obj <- addClusterization(obj, clName = "merge", clusters = mergedClusters,
                            coexDF = mergedCoexDF, override = FALSE)
 
-  expect_identical(reorderClusterization(obj),
+  expect_identical(reorderClusterization(obj)[1:2],
                    list("clusters" = mergedClusters, "coex" = mergedCoexDF))
 
   mergedLfcDF <- logFoldChangeOnClusters(obj, clName = "merge")

--- a/vignettes/Guided_tutorial_v2.Rmd
+++ b/vignettes/Guided_tutorial_v2.Rmd
@@ -456,6 +456,13 @@ c(mergeClusters, mergeCoexDF) %<-%
                             optimizeForSpeed = TRUE, cores = 6L,
                             saveObj = TRUE, outDir = outDir)
 
+# merges are:
+#  1 <- '-1' + 1 + 4
+#  2 <- 2 + 3 + 8
+#  3 <- 5
+#  4 <- 6
+#  5 <- 7
+
 obj <- addClusterization(obj, clName = "merge",
                          clusters = mergeClusters, coexDF = mergeCoexDF)
 ```
@@ -465,12 +472,12 @@ very well to the expression of the layers' genes defined above...
 
 ```{r eval=FALSE, include=TRUE}
 clustersMarkersHeatmapPlot(obj, groupMarkers = layersGenes,
-                           clName = "split", kCuts = 6L)
+                           clName = "split", kCuts = 5L)
 ```
 
 ```{r}
 clustersMarkersHeatmapPlot(obj, groupMarkers = layersGenes,
-                           clName = "merge", kCuts = 6L)
+                           clName = "merge", kCuts = 5L)
 ```
 
 ## Vignette clean-up stage

--- a/vignettes/Guided_tutorial_v2.Rmd
+++ b/vignettes/Guided_tutorial_v2.Rmd
@@ -16,9 +16,9 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk[["set"]](
   collapse = TRUE,
-  comment = "#>",
-  fig.width = 5L,
-  fig.height = 5L
+  comment = "#>"
+#  fig.width = 5L,
+#  fig.height = 5L
 )
 
 ```
@@ -409,47 +409,68 @@ UMAPPlot(pcaClustersDF[, 1L:10L],
 ## Uniform Clustering
 
 It is possible to obtain a cell clusterization based on the concept of 
-uniformity of expression of the genes across the cells. That is the cluster
-satisfies the null hypothesis of the `COTAN` model:
+*uniformity* of expression of the genes across the cells.
+That is the cluster satisfies the null hypothesis of the `COTAN` model:
 the genes expression is not dependent on the cell in consideration.
 
+There are two functions involved into obtaining a proper clusterization:
+the first is `cellsUniformClustering` that uses standard tools clusterization
+methods, but then discards and re-clusters any *non-uniform* cluster.
+Please not that the most important parameter for the users is the
+`GDIThreshold`: it defines how strict is the uniformity check,
+good values are between 1.42 (more strict) and 1.43 (less strict).
+
 ```{r eval=FALSE, include=TRUE}
-c(fineClusters, fineCoexDF) %<-%
+c(splitClusters, splitCoexDF) %<-%
   cellsUniformClustering(obj, GDIThreshold = 1.43, initialResolution = 0.8,
                          optimizeForSpeed = TRUE, cores = 6L,
                          saveObj = TRUE, outDir = outDir)
-obj <- addClusterization(obj, clName = "Fine",
-                         clusters = fineClusters, coexDF = fineCoexDF)
+obj <- addClusterization(obj, clName = "split",
+                         clusters = splitClusters, coexDF = splitCoexDF)
 ```
-
 
 In the case one already has an existing clusterization, it is possible to
 calculate the *DEA* `data.frame` and add it to the `COTAN` object.
 ```{r eval=FALSE, include=TRUE}
-fineCoexDF <- DEAOnClusters(obj, clusters = fineClusters)
+splitCoexDF <- DEAOnClusters(obj, clusters = splitClusters)
 
-obj <- addClusterization(obj, clName = "Fine",
-                         clusters = fineClusters, coexDF = fineCoexDF)
+obj <- addClusterization(obj, clName = "split",
+                         clusters = splitClusters, coexDF = splitCoexDF)
 ```
 
-
-However since the algorithm to create the clusters is not geared directly
+However since the algorithm that creates the clusters is not geared directly
 to achieve cluster uniformity, there might be clusters that can be merged back
-together and still be uniform.
+together and still be uniform. This is the purpose of the function 
+`mergeUniformCellsClusters` that takes a clusterization and tries to merge
+cluster pairs after checking that together the pair forms a uniform cluster.
+In order to avoid the massive possible checks the function relies on a *related*
+distance the find the cluster pairs that will be most likely merged. 
+Again the most important parameter for the users is the `GDIThreshold`, it is 
+supposed to be the same as the one used to generate the clusterization in the
+first place, but if needed it can be slightly relaxed in order to reduce the
+number of clusters.
+
 ```{r eval=FALSE, include=TRUE}
-c(mergedClusters, mergedCoexDF) %<-%
-  mergeUniformCellsClusters(obj, GDIThreshold = 1.43,
+c(mergeClusters, mergeCoexDF) %<-%
+  mergeUniformCellsClusters(obj, clusters = splitClusters, GDIThreshold = 1.43,
                             optimizeForSpeed = TRUE, cores = 6L,
                             saveObj = TRUE, outDir = outDir)
 
-obj <- addClusterization(obj, clName = "Merged",
-                         clusters = mergedClusters, coexDF = mergedCoexDF)
+obj <- addClusterization(obj, clName = "merge",
+                         clusters = mergeClusters, coexDF = mergeCoexDF)
 ```
 
+In the following graph, it is possible to check that the found clusters align
+very well to the expression of the layers' genes defined above...
 
 ```{r eval=FALSE, include=TRUE}
 clustersMarkersHeatmapPlot(obj, groupMarkers = layersGenes,
-                           clName = "Merged", kCuts = 6L)
+                           clName = "split", kCuts = 6L)
+```
+
+```{r}
+clustersMarkersHeatmapPlot(obj, groupMarkers = layersGenes,
+                           clName = "merge", kCuts = 6L)
 ```
 
 ## Vignette clean-up stage

--- a/vignettes/Guided_tutorial_v2.Rmd
+++ b/vignettes/Guided_tutorial_v2.Rmd
@@ -475,7 +475,7 @@ clustersMarkersHeatmapPlot(obj, groupMarkers = layersGenes,
                            clName = "split", kCuts = 5L)
 ```
 
-```{r}
+```{r eval=FALSE, include=TRUE}
 clustersMarkersHeatmapPlot(obj, groupMarkers = layersGenes,
                            clName = "merge", kCuts = 5L)
 ```


### PR DESCRIPTION
Speed-up of the functions `parallelDispersionBisection()` and `parallelNuBisection()` vias use of `Rfast::rowsums() and `Rfast::colsums()` respectively

Speed-up of function `logFoldChangeOnClusters()` by using overall sum for all clusters instead of calculating out-sums each time

Used `torch::torch_mm()` instead of `torch::torch_matmul()` as it implies less overhead:
it is specialized for 2D tensor multiplications