### PR TITLE
Allow 'above ratio threshold' as input to cell clustering methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## 2.5.3
+
+Now `checkClusterUniformity()` can take as input the `ratioAboveThreshold`:
+the fraction of genes allowed to be above the given `GDIThreshold`
+
 ## 2.5.2
 
 Solved issue with usage checks about the `torch` library

--- a/R/cellsUniformClustering.R
+++ b/R/cellsUniformClustering.R
@@ -448,8 +448,9 @@ cellsUniformClustering <- function(objCOTAN,
     outputClusters[unclusteredCells] <- "-1"
     outputClusters <- set_names(outputClusters, getCells(objCOTAN))
 
-    allCheckResults <- allCheckResults[clTags, , drop = FALSE]
-    rownames(allCheckResults) <- clTagsMap[clTags]
+    checksTokeep <- rownames(allCheckResults) %in% clTags
+    allCheckResults <- allCheckResults[checksTokeep, , drop = FALSE]
+    rownames(allCheckResults) <- clTagsMap[rownames(allCheckResults)]
     if (any(unclusteredCells)) {
       errorCheckResults[["size"]] <- length(unclusteredCells)
       allCheckResults <- rbind(allCheckResults, "-1" = errorCheckResults)

--- a/R/cellsUniformClustering.R
+++ b/R/cellsUniformClustering.R
@@ -243,7 +243,7 @@ cellsUniformClustering <- function(objCOTAN,
   srat <- NULL
   allCheckResults <- data.frame()
   errorCheckResults <- list("isUniform" = FALSE, "fractionAbove" = NA,
-                            "firstPercentile" = NA, "size" = NA)
+                            "ratioQuantile" = NA, "size" = NA)
 
   repeat {
     iter <- iter + 1L
@@ -332,6 +332,7 @@ cellsUniformClustering <- function(objCOTAN,
                                  clusterName = globalClName,
                                  cells = cells,
                                  GDIThreshold = GDIThreshold,
+#                                 ratioAboveThreshold = ratioAboveThreshold,
                                  cores = cores,
                                  optimizeForSpeed = optimizeForSpeed,
                                  deviceStr = deviceStr,

--- a/R/cellsUniformClustering.R
+++ b/R/cellsUniformClustering.R
@@ -153,6 +153,8 @@ NULL
 #' @param objCOTAN a `COTAN` object
 #' @param GDIThreshold the threshold level that discriminates uniform
 #'   *clusters*. It defaults to \eqn{1.43}
+#' @param ratioAboveThreshold the fraction of genes allowed to be above the
+#'   `GDIThreshold`. It defaults to \eqn{1\%}
 #' @param cores number of cores to use. Default is 1.
 #' @param maxIterations max number of re-clustering iterations. It defaults to
 #'   \eqn{25}
@@ -206,6 +208,7 @@ NULL
 
 cellsUniformClustering <- function(objCOTAN,
                                    GDIThreshold = 1.43,
+                                   ratioAboveThreshold = 0.01,
                                    cores = 1L,
                                    maxIterations = 25L,
                                    optimizeForSpeed = TRUE,
@@ -332,7 +335,7 @@ cellsUniformClustering <- function(objCOTAN,
                                  clusterName = globalClName,
                                  cells = cells,
                                  GDIThreshold = GDIThreshold,
-#                                 ratioAboveThreshold = ratioAboveThreshold,
+                                 ratioAboveThreshold = ratioAboveThreshold,
                                  cores = cores,
                                  optimizeForSpeed = optimizeForSpeed,
                                  deviceStr = deviceStr,

--- a/R/checkClusterUniformity.R
+++ b/R/checkClusterUniformity.R
@@ -110,7 +110,7 @@ checkClusterUniformity <- function(
   gc()
 
   # A cluster is deemed uniform if the number of genes
-  # with [GDI > GDIThreshold] is not more than 1%
+  # with [GDI > GDIThreshold] is at the most ratioAboveThreshold
   gdi <- GDIData[["GDI"]]
 
   quantAboveThr <- quantile(gdi, probs = 1.0 - ratioAboveThreshold)

--- a/R/checkClusterUniformity.R
+++ b/R/checkClusterUniformity.R
@@ -3,14 +3,18 @@
 #' @details `checkClusterUniformity()` takes a `COTAN` object and a cells'
 #'   *cluster* and checks whether the latter is **uniform** by `GDI`. The
 #'   function runs `COTAN` to check whether the `GDI` is lower than the given
-#'   `GDIThreshold` for the \eqn{99\%} of the genes. If the `GDI` results to be
-#'   too high for too many genes, the *cluster* is deemed **non-uniform**.
+#'   `GDIThreshold` (1.43) for all but at the most `ratioAboveThreshold`
+#'   (\eqn{1\%}) genes. If the `GDI` results to be too high for too many genes,
+#'   the *cluster* is deemed
+#'   **non-uniform**.
 #'
 #' @param objCOTAN a `COTAN` object
 #' @param clusterName the tag of the *cluster*
 #' @param cells the cells belonging to the *cluster*
 #' @param GDIThreshold the threshold level that discriminates uniform
 #'   *clusters*. It defaults to \eqn{1.43}
+#' @param ratioAboveThreshold the fraction of genes allowed to be above the
+#'   `GDIThreshold`. It defaults to \eqn{1\%}
 #' @param cores number of cores to use. Default is 1.
 #' @param optimizeForSpeed Boolean; when `TRUE` `COTAN` tries to use the `torch`
 #'   library to run the matrix calculations. Otherwise, or when the library is
@@ -27,7 +31,8 @@
 #' @returns `checkClusterUniformity` returns a list with:
 #'   * `"isUniform"`: a flag indicating whether the *cluster* is **uniform**
 #'   * `"fractionAbove"`: the percentage of genes with `GDI` above the threshold
-#'   * `"firstPercentile"`: the quantile associated to the highest percentile
+#'   * `"ratioQuantile"`: the quantile associated to the high quantile
+#'   associated to given ratio
 #'   * `"size"`: the number of cells in the cluster
 #'
 #' @importFrom utils head
@@ -45,11 +50,17 @@
 #' @rdname UniformClusters
 #'
 
-checkClusterUniformity <- function(objCOTAN, clusterName, cells,
-                                   GDIThreshold = 1.43, cores = 1L,
-                                   optimizeForSpeed = TRUE, deviceStr = "cuda",
-                                   saveObj = TRUE, outDir = ".") {
-
+checkClusterUniformity <- function(
+    objCOTAN,
+    clusterName,
+    cells,
+    GDIThreshold = 1.43,
+    ratioAboveThreshold = 0.01,
+    cores = 1L,
+    optimizeForSpeed = TRUE,
+    deviceStr = "cuda",
+    saveObj = TRUE,
+    outDir = ".") {
   cellsToDrop <- getCells(objCOTAN)[!getCells(objCOTAN) %in% cells]
 
   objCOTAN <- dropGenesCells(objCOTAN, cells = cellsToDrop)
@@ -102,17 +113,18 @@ checkClusterUniformity <- function(objCOTAN, clusterName, cells,
   # with [GDI > GDIThreshold] is not more than 1%
   gdi <- GDIData[["GDI"]]
 
-  quantAboveThr <- quantile(gdi, probs = 0.99)
+  quantAboveThr <- quantile(gdi, probs = 1.0 - ratioAboveThreshold)
   percAboveThr <- sum(gdi >= GDIThreshold) / length(gdi)
 
-  clusterIsUniform <- percAboveThr <= 0.01
+  clusterIsUniform <- percAboveThr <= ratioAboveThreshold
 
-  logThis(paste0("Cluster ", clusterName, ", with size ", clusterSize, ", is ",
-                 (if (clusterIsUniform) {""} else {"not "}), "uniform\n",
-                 round(percAboveThr * 100.0, digits = 2L),
-                 "% of the genes is above the given GDI threshold ",
-                 GDIThreshold, "\n", "GDI 99% quantile is at ",
-                 round(quantAboveThr, digits = 4L)), logLevel = 3L)
+  logThis(paste0(
+    "Cluster ", clusterName, ", with size ", clusterSize, ", is ",
+    (if (clusterIsUniform) {""} else {"not "}), "uniform\n",
+    round(percAboveThr * 100.0, digits = 2L), "% of the genes is above ",
+    "the given GDI threshold ", GDIThreshold, "\n",
+    "highest ", round(ratioAboveThreshold * 100.0, digits = 2L),
+    "% GDI quantile is at ", round(quantAboveThr, digits = 4L)), logLevel = 3L)
 
   if (isTRUE(saveObj)) tryCatch({
       pre <- ""
@@ -131,6 +143,6 @@ checkClusterUniformity <- function(objCOTAN, clusterName, cells,
 
   return(list("isUniform" = clusterIsUniform,
               "fractionAbove" = percAboveThr,
-              "firstPercentile" = quantAboveThr[[1L]],
+              "ratioQuantile" = quantAboveThr[[1L]],
               "size" = clusterSize))
 }

--- a/R/mergeUniformCellsClusters.R
+++ b/R/mergeUniformCellsClusters.R
@@ -200,7 +200,7 @@ mergeUniformCellsClusters <- function(objCOTAN,
   errorCheckResults <- list("isUniform" = FALSE, "fractionAbove" = NA,
                             "ratioQuantile" = NA, "size" = NA)
 
-  testPairListMerge <- function(pList) {
+  testPairListMerge <- function(pList, allCheckResults) {
     logThis(paste0("Clusters pairs for merging:\n",
                    paste(pList, collapse = " ")), logLevel = 1L)
 
@@ -266,7 +266,8 @@ mergeUniformCellsClusters <- function(objCOTAN,
       }
     }
 
-    return(list("oc" = outputClusters, "nm" = notMergeable))
+    return(list("oc" = outputClusters, "nm" = notMergeable,
+                "acr" = allCheckResults))
   }
 
   repeat {
@@ -321,7 +322,8 @@ mergeUniformCellsClusters <- function(objCOTAN,
     numPairsToTest <- min(batchSize, length(pList))
     pList <- pList[1L:numPairsToTest]
 
-    c(outputClusters, notMergeable) %<-% testPairListMerge(pList)
+    c(outputClusters, notMergeable, allCheckResults) %<-%
+      testPairListMerge(pList, allCheckResults)
 
     newNumClusters <- length(unique(outputClusters))
     if (newNumClusters == 1L) {
@@ -375,8 +377,9 @@ mergeUniformCellsClusters <- function(objCOTAN,
     outputClusters <- clTagsMap[outputClusters]
     outputClusters <- set_names(outputClusters, getCells(objCOTAN))
 
-    allCheckResults <- allCheckResults[clTags, , drop = FALSE]
-    rownames(allCheckResults) <- clTagsMap[clTags]
+    checksTokeep <- rownames(allCheckResults) %in% clTags
+    allCheckResults <- allCheckResults[checksTokeep, , drop = FALSE]
+    rownames(allCheckResults) <- clTagsMap[rownames(allCheckResults)]
   }
 
   outputCoexDF <-

--- a/R/mergeUniformCellsClusters.R
+++ b/R/mergeUniformCellsClusters.R
@@ -101,6 +101,7 @@
 #' firstCluster <- getCells(objCOTAN)[clusters %in% clusters[[1L]]]
 #' firstClusterIsUniform <-
 #'   checkClusterUniformity(objCOTAN, GDIThreshold = 1.46,
+#'                          ratioAboveThreshold = 0.01,
 #'                          cluster = clusters[[1L]], cells = firstCluster,
 #'                          cores = 6L, optimizeForSpeed = TRUE,
 #'                          deviceStr = "cuda", saveObj = FALSE)[["isUniform"]]
@@ -193,7 +194,7 @@ mergeUniformCellsClusters <- function(objCOTAN,
   iter <- 0L
   allCheckResults <- data.frame()
   errorCheckResults <- list("isUniform" = FALSE, "fractionAbove" = NA,
-                            "firstPercentile" = NA, "size" = NA)
+                            "ratioQuantile" = NA, "size" = NA)
 
   testPairListMerge <- function(pList) {
     logThis(paste0("Clusters pairs for merging:\n",
@@ -229,6 +230,7 @@ mergeUniformCellsClusters <- function(objCOTAN,
                                clusterName = mergedClName,
                                cells = mergedCluster,
                                GDIThreshold = GDIThreshold,
+#                               ratioAboveThreshold = ratioAboveThreshold,
                                cores = cores,
                                optimizeForSpeed = optimizeForSpeed,
                                deviceStr = deviceStr,

--- a/R/mergeUniformCellsClusters.R
+++ b/R/mergeUniformCellsClusters.R
@@ -15,6 +15,8 @@
 #'   significant!
 #' @param GDIThreshold the threshold level that discriminates uniform clusters.
 #'   It defaults to \eqn{1.43}
+#' @param ratioAboveThreshold the fraction of genes allowed to be above the
+#'   `GDIThreshold`. It defaults to \eqn{1\%}
 #' @param batchSize Number pairs to test in a single round. If none of them
 #'   succeeds the merge stops. Defaults to \eqn{2 (\#cl)^{2/3}}
 #' @param notMergeable An array of names of merged clusters that are already
@@ -117,7 +119,8 @@
 #' identical(reorderClusterization(objCOTAN)[["clusters"]], clusters)
 #'
 #' mergedList <- mergeUniformCellsClusters(objCOTAN,
-#'                                         GDIThreshold = 1.46,
+#'                                         GDIThreshold = 1.43,
+#'                                         ratioAboveThreshold = 0.02,
 #'                                         batchSize = 5L,
 #'                                         clusters = clusters,
 #'                                         cores = 6L,
@@ -140,6 +143,7 @@
 mergeUniformCellsClusters <- function(objCOTAN,
                                       clusters = NULL,
                                       GDIThreshold = 1.43,
+                                      ratioAboveThreshold = 0.01,
                                       batchSize = 0L,
                                       notMergeable = NULL,
                                       cores = 1L,
@@ -230,7 +234,7 @@ mergeUniformCellsClusters <- function(objCOTAN,
                                clusterName = mergedClName,
                                cells = mergedCluster,
                                GDIThreshold = GDIThreshold,
-#                               ratioAboveThreshold = ratioAboveThreshold,
+                               ratioAboveThreshold = ratioAboveThreshold,
                                cores = cores,
                                optimizeForSpeed = optimizeForSpeed,
                                deviceStr = deviceStr,

--- a/man/UniformClusters.Rd
+++ b/man/UniformClusters.Rd
@@ -39,6 +39,7 @@ checkClusterUniformity(
   clusterName,
   cells,
   GDIThreshold = 1.43,
+  ratioAboveThreshold = 0.01,
   cores = 1L,
   optimizeForSpeed = TRUE,
   deviceStr = "cuda",
@@ -123,6 +124,9 @@ output will be paced in a sub-folder.}
 
 \item{cells}{the cells belonging to the \emph{cluster}}
 
+\item{ratioAboveThreshold}{the fraction of genes allowed to be above the
+\code{GDIThreshold}. It defaults to \eqn{1\%}}
+
 \item{clusters}{The \emph{clusterization} to merge. If not given the last
 available \emph{clusterization} will be used, as it is probably the most
 significant!}
@@ -147,7 +151,8 @@ an interruption.}
 \itemize{
 \item \code{"isUniform"}: a flag indicating whether the \emph{cluster} is \strong{uniform}
 \item \code{"fractionAbove"}: the percentage of genes with \code{GDI} above the threshold
-\item \code{"firstPercentile"}: the quantile associated to the highest percentile
+\item \code{"ratioQuantile"}: the quantile associated to the high quantile
+associated to given ratio
 \item \code{"size"}: the number of cells in the cluster
 }
 
@@ -180,8 +185,10 @@ deemed \strong{uniform}. In the case only a few cells are left out (\eqn{\leq
 \code{checkClusterUniformity()} takes a \code{COTAN} object and a cells'
 \emph{cluster} and checks whether the latter is \strong{uniform} by \code{GDI}. The
 function runs \code{COTAN} to check whether the \code{GDI} is lower than the given
-\code{GDIThreshold} for the \eqn{99\%} of the genes. If the \code{GDI} results to be
-too high for too many genes, the \emph{cluster} is deemed \strong{non-uniform}.
+\code{GDIThreshold} (1.43) for all but at the most \code{ratioAboveThreshold}
+(\eqn{1\%}) genes. If the \code{GDI} results to be too high for too many genes,
+the \emph{cluster} is deemed
+\strong{non-uniform}.
 
 \code{mergeUniformCellsClusters()} takes in a \strong{uniform}
 \emph{clusterization} and iteratively checks whether merging two \emph{near clusters}
@@ -226,6 +233,7 @@ clusters <- splitList[["clusters"]]
 firstCluster <- getCells(objCOTAN)[clusters \%in\% clusters[[1L]]]
 firstClusterIsUniform <-
   checkClusterUniformity(objCOTAN, GDIThreshold = 1.46,
+                         ratioAboveThreshold = 0.01,
                          cluster = clusters[[1L]], cells = firstCluster,
                          cores = 6L, optimizeForSpeed = TRUE,
                          deviceStr = "cuda", saveObj = FALSE)[["isUniform"]]

--- a/man/UniformClusters.Rd
+++ b/man/UniformClusters.Rd
@@ -21,6 +21,7 @@ GDIPlot(
 cellsUniformClustering(
   objCOTAN,
   GDIThreshold = 1.43,
+  ratioAboveThreshold = 0.01,
   cores = 1L,
   maxIterations = 25L,
   optimizeForSpeed = TRUE,
@@ -51,6 +52,7 @@ mergeUniformCellsClusters(
   objCOTAN,
   clusters = NULL,
   GDIThreshold = 1.43,
+  ratioAboveThreshold = 0.01,
   batchSize = 0L,
   notMergeable = NULL,
   cores = 1L,
@@ -80,6 +82,9 @@ It defaults to \eqn{1.43}}
 
 \item{GDIIn}{when the \code{GDI} data frame was already calculated, it can be put
 here to speed up the process (default is \code{NULL})}
+
+\item{ratioAboveThreshold}{the fraction of genes allowed to be above the
+\code{GDIThreshold}. It defaults to \eqn{1\%}}
 
 \item{cores}{number of cores to use. Default is 1.}
 
@@ -123,9 +128,6 @@ output will be paced in a sub-folder.}
 \item{clusterName}{the tag of the \emph{cluster}}
 
 \item{cells}{the cells belonging to the \emph{cluster}}
-
-\item{ratioAboveThreshold}{the fraction of genes allowed to be above the
-\code{GDIThreshold}. It defaults to \eqn{1\%}}
 
 \item{clusters}{The \emph{clusterization} to merge. If not given the last
 available \emph{clusterization} will be used, as it is probably the most
@@ -249,7 +251,8 @@ objCOTAN <- addClusterizationCoex(objCOTAN,
 identical(reorderClusterization(objCOTAN)[["clusters"]], clusters)
 
 mergedList <- mergeUniformCellsClusters(objCOTAN,
-                                        GDIThreshold = 1.46,
+                                        GDIThreshold = 1.43,
+                                        ratioAboveThreshold = 0.02,
                                         batchSize = 5L,
                                         clusters = clusters,
                                         cores = 6L,

--- a/tests/outputTestDatasetCreation.R
+++ b/tests/outputTestDatasetCreation.R
@@ -43,10 +43,11 @@ outputTestDatasetCreation <- function(testsDir = file.path("tests",
   saveRDS(pval.test, file.path(testsDir, "pval.test.RDS"))
 
   GDIThreshold <- 1.46
+  ratioAboveThreshold <- 0.01
   initialResolution <- 0.8
-
   clusters <- cellsUniformClustering(obj, GDIThreshold = GDIThreshold,
-                                     initialResolution =   initialResolution,
+                                     ratioAboveThreshold = ratioAboveThreshold,
+                                     initialResolution   = initialResolution,
                                      cores = 6L, saveObj = FALSE)[["clusters"]]
   saveRDS(clusters, file.path(testsDir, "clusters1.RDS"))
 

--- a/tests/testthat/test-cellsUniformClustering.R
+++ b/tests/testthat/test-cellsUniformClustering.R
@@ -16,6 +16,7 @@ test_that("Cell Uniform Clustering", {
                        cores = 6L, saveObj = TRUE, outDir = tm)
 
   GDIThreshold <- 1.46
+  ratioAboveThreshold <- 0.01
   initialResolution <- 0.8
   suppressWarnings({
     c(clusters, coexDF) %<-%
@@ -46,6 +47,7 @@ test_that("Cell Uniform Clustering", {
   suppressWarnings({
     c(isUniform, fracAbove, firstPerc, clSize) %<-%
       checkClusterUniformity(obj, GDIThreshold = GDIThreshold,
+                             ratioAboveThreshold = ratioAboveThreshold,
                              clusterName = paste0("Cluster_", firstCl),
                              cells = names(clusters)[clusters == firstCl],
                              optimizeForSpeed = TRUE, deviceStr = "cpu",

--- a/tests/testthat/test-cellsUniformClustering.R
+++ b/tests/testthat/test-cellsUniformClustering.R
@@ -21,6 +21,7 @@ test_that("Cell Uniform Clustering", {
   suppressWarnings({
     c(clusters, coexDF) %<-%
       cellsUniformClustering(obj, GDIThreshold = GDIThreshold,
+                             ratioAboveThreshold = ratioAboveThreshold,
                              initialResolution = initialResolution,
                              cores = 6L, optimizeForSpeed = TRUE,
                              deviceStr = "cuda", saveObj = TRUE, outDir = tm)
@@ -54,7 +55,7 @@ test_that("Cell Uniform Clustering", {
                              saveObj = TRUE, outDir = tm)
   })
   expect_true(isUniform)
-  expect_lte(fracAbove, 0.01)
+  expect_lte(fracAbove, ratioAboveThreshold)
   expect_lte(firstPerc, GDIThreshold)
   expect_identical(clSize, sum(clusters == firstCl))
 
@@ -91,12 +92,13 @@ test_that("Cell Uniform Clustering", {
   exactClusters <- set_names(rep(1L:2L, each = 600L), nm = getCells(obj))
 
   suppressWarnings({
-    splitList <- cellsUniformClustering(obj, GDIThreshold = GDIThreshold,
-                                        initialResolution = initialResolution,
-                                        initialClusters = exactClusters,
-                                        cores = 6L, optimizeForSpeed = FALSE,
-                                        deviceStr = "cpu", saveObj = TRUE,
-                                        outDir = tm)
+    splitList <- cellsUniformClustering(
+      obj, GDIThreshold = GDIThreshold,
+      ratioAboveThreshold = ratioAboveThreshold,
+      initialResolution = initialResolution,
+      initialClusters = exactClusters,
+      cores = 6L, optimizeForSpeed = FALSE,
+      deviceStr = "cpu", saveObj = TRUE, outDir = tm)
   })
 
   expect_identical(splitList[["clusters"]], factor(exactClusters))
@@ -147,7 +149,7 @@ test_that("Cell Uniform Clustering", {
 
     GDI_data <- calculateGDI(temp.obj)
 
-    expect_lt(nrow(GDI_data[GDI_data[["GDI"]] >= GDIThreshold, ]),
-              0.01 * nrow(GDI_data))
+    expect_lte(nrow(GDI_data[GDI_data[["GDI"]] >= GDIThreshold, ]),
+               ratioAboveThreshold * nrow(GDI_data))
   }
 })

--- a/tests/testthat/test-mergeUniformCellsClusters.R
+++ b/tests/testthat/test-mergeUniformCellsClusters.R
@@ -55,6 +55,7 @@ test_that("Merge Uniform Cells Clusters", {
   expect_equal(pValDF[genes.names.test, ], pValDF_exp, tolerance = 1.0e-12)
 
   GDIThreshold <- 1.46
+  ratioAboveThreshold <- 0.01
 
   deltaExpression <- clustersDeltaExpression(obj)
 
@@ -77,10 +78,12 @@ test_that("Merge Uniform Cells Clusters", {
 
   suppressWarnings({
     c(mergedClusters, mergedCoexDF) %<-%
-      mergeUniformCellsClusters(objCOTAN = obj, clusters = clusters, cores = 6L,
-                                GDIThreshold = GDIThreshold,
-                                distance = "cosine", hclustMethod = "ward.D2",
-                                saveObj = TRUE, outDir = tm)
+      mergeUniformCellsClusters(
+        objCOTAN = obj, clusters = clusters,
+        GDIThreshold = GDIThreshold,
+        ratioAboveThreshold = ratioAboveThreshold,
+        distance = "cosine", hclustMethod = "ward.D2",
+        cores = 6L, saveObj = TRUE, outDir = tm)
   })
   expect_true(file.exists(file.path(tm, "test", "leafs_merge",
                                     "merge_clusterization_1.csv")))
@@ -118,7 +121,8 @@ test_that("Merge Uniform Cells Clusters", {
 
     GDIData <- calculateGDI(clObj)
 
-    expect_lte(sum(GDIData[["GDI"]] >= GDIThreshold), 0.01 * nrow(GDIData))
+    expect_lte(sum(GDIData[["GDI"]] >= GDIThreshold),
+               ratioAboveThreshold * nrow(GDIData))
 
     gc()
   }

--- a/vignettes/Guided_tutorial_v2.Rmd
+++ b/vignettes/Guided_tutorial_v2.Rmd
@@ -54,8 +54,8 @@ if (!file.exists(dataSetFile)) {
   getGEOSuppFiles(GEO, makeDirectory = TRUE,
                   baseDir = dataDir, fetch_files = TRUE,
                   filter_regex = fName)
-  sample.dataset <- read.csv(dataSetFile, sep = "\t", row.names = 1L)
 }
+sample.dataset <- read.csv(dataSetFile, sep = "\t", row.names = 1L)
 ```
 
 Define a directory where the output will be stored.


### PR DESCRIPTION
Up to now the fraction of genes allowed to be above the GDI threshold for uniform clusters was hard-coded to be 1%.
Now it can be set by users if necessary...

Also fixed small bug in reported uniformity checks for cell clustering methods