### PR TITLE
Improved usability of the method `storeGDI()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: COTAN
 Type: Package
 Title: COexpression Tables ANalysis 
-Version: 2.5.5
+Version: 2.5.6
 Authors@R: c(
   person("Galfrè", "Silvia Giulia",email = "silvia.galfre@di.unipi.it", role=c("aut","cre"),comment = c(ORCID = "0000-0002-2770-0344")),
   person("Morandin","Francesco", email = "francesco.morandin@unipr.it", role = "aut",comment = c(ORCID = "0000-0002-2022-2300")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## 2.5.6
+
+Now the method `storeGDI()` can take in the output `data.frame` from
+the function `calculateGDI()`
+
 ## 2.5.5
 
 Stopped function `cellsUniformClustering()` from saving the internally created

--- a/R/COTAN-getters.R
+++ b/R/COTAN-getters.R
@@ -894,7 +894,7 @@ NULL
 #' ## G <- calculateG(objCOTAN)
 #' ## pValue <- calculatePValue(objCOTAN)
 #' gdiDF <- calculateGDI(objCOTAN)
-#' objCOTAN <- storeGDI(objCOTAN, genesGDI = getColumnFromDF(gdiDF, "GDI"))
+#' objCOTAN <- storeGDI(objCOTAN, genesGDI = gdiDF)
 #'
 #' ## Touching any of the lambda/nu/dispersino parameters invalidates the `COEX`
 #' ## matrix and derivatives, so it can be dropped it from the `COTAN` object
@@ -1077,7 +1077,8 @@ setMethod(
 
 #' @aliases getGDI
 #'
-#' @details `getGDI()` extracts the genes' **GDI** array
+#' @details `getGDI()` extracts the genes' **GDI** array as it was stored by the
+#'   method [storeGDI()]
 #'
 #' @param objCOTAN a `COTAN` object
 #'

--- a/R/COTAN-modifiers.R
+++ b/R/COTAN-modifiers.R
@@ -197,10 +197,11 @@ setMethod(
 #' @aliases storeGDI
 #'
 #' @details `storeGDI()` stored and already calculated genes' GDI `array` in a
-#'   `COTAN` object
+#'   `COTAN` object. It can be retrieved using the method [getGDI()]
 #'
 #' @param objCOTAN a `COTAN` object
-#' @param genesGDI the genes' GDI `array` to store
+#' @param genesGDI the named genes' GDI `array` to store or the output
+#'   `data.frame` of the function [calculateGDI()]
 #'
 #' @returns `storeGDI()` returns the given `COTAN` object  with updated
 #'   **GDI** genes' information
@@ -215,6 +216,12 @@ setMethod(
   "storeGDI",
   "COTAN",
   function(objCOTAN, genesGDI) {
+    if (isa(genesGDI, "data.frame")) {
+      assert_that("GDI" %in% colnames(genesGDI),
+                  msg = "Passed data.frame has no GDI column")
+      genesGDI <- getColumnFromDF(genesGDI, colName = "GDI")
+    }
+
     allGenes <- getGenes(objCOTAN)
     assert_that(setequal(names(genesGDI), allGenes),
                 msg = paste("Passed GDI array must be named",

--- a/man/CalculatingCOEX.Rd
+++ b/man/CalculatingCOEX.Rd
@@ -439,7 +439,7 @@ identical(partialGenesCoex,
 ## G <- calculateG(objCOTAN)
 ## pValue <- calculatePValue(objCOTAN)
 gdiDF <- calculateGDI(objCOTAN)
-objCOTAN <- storeGDI(objCOTAN, genesGDI = getColumnFromDF(gdiDF, "GDI"))
+objCOTAN <- storeGDI(objCOTAN, genesGDI = gdiDF)
 
 ## Touching any of the lambda/nu/dispersino parameters invalidates the `COEX`
 ## matrix and derivatives, so it can be dropped it from the `COTAN` object

--- a/man/GenesStatistics.Rd
+++ b/man/GenesStatistics.Rd
@@ -54,7 +54,8 @@ calculatePDI(
 \arguments{
 \item{objCOTAN}{a \code{COTAN} object}
 
-\item{genesGDI}{the genes' GDI \code{array} to store}
+\item{genesGDI}{the named genes' GDI \code{array} to store or the output
+\code{data.frame} of the function \code{\link[=calculateGDI]{calculateGDI()}}}
 
 \item{primaryMarkers}{A vector of primary marker names.}
 
@@ -149,10 +150,11 @@ denote it as \emph{Local Differentiation Index} (\code{LDI}) relative to the sel
 subset.
 }
 \details{
-\code{getGDI()} extracts the genes' \strong{GDI} array
+\code{getGDI()} extracts the genes' \strong{GDI} array as it was stored by the
+method \code{\link[=storeGDI]{storeGDI()}}
 
 \code{storeGDI()} stored and already calculated genes' GDI \code{array} in a
-\code{COTAN} object
+\code{COTAN} object. It can be retrieved using the method \code{\link[=getGDI]{getGDI()}}
 
 \code{genesCoexSpace()} calculates genes groups based on the primary
 markers and uses them to prepare the genes' \code{COEX} space \code{data.frame}.

--- a/vignettes/Guided_tutorial_v2.Rmd
+++ b/vignettes/Guided_tutorial_v2.Rmd
@@ -341,11 +341,11 @@ obj2 <- automaticCOTANObjectCreation(
 To calculate and store the Global Differentiation Index (`GDI`) we can run:
 
 ```{r}
-quantP <- calculateGDI(obj)
+gdiDF <- calculateGDI(obj)
 
-head(quantP)
+head(gdiDF)
 
-obj <- storeGDI(obj, genesGDI = getColumnFromDF(quantP, "GDI"))
+obj <- storeGDI(obj, genesGDI = gdiDF)
 ```
 
 The next function can either plot the `GDI` for the dataset directly or
@@ -365,11 +365,7 @@ genesList <- list(
              "Tars", "Amacr")
 )
 
-# needs to be recalculated after the changes in nu/dispersion above
-#obj <- calculateCoex(obj, actOnCells = FALSE)
-
-GDIPlot(obj, GDIIn = quantP, cond = cond,
-        genes = genesList, GDIThreshold = 1.43)
+GDIPlot(obj, cond = cond, genes = genesList, GDIThreshold = 1.43)
 ```
 
 The percentage of cells expressing the gene in the third column of this
@@ -390,6 +386,7 @@ conditions to get a complete overview.
 ```{r eval=FALSE}
 print(cond)
 ```
+
 
 ```{r eval=FALSE}
 heatmapPlot(genesLists = genesList, sets = (1L:3L),


### PR DESCRIPTION
Now the method `storeGDI()` can take in the output `data.frame` from the function `calculateGDI()`