### PR TITLE
Fixed bug in function `genesCoexSpace()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+Fixed bug in function `genesCoexSpace()`: now `primaryMarkers` can have only a
+single gene
+
 ## 2.5.9
 
 Exported utility functions about names arrays: `conditionsFromNames()`,

--- a/R/establishGenesClusters.R
+++ b/R/establishGenesClusters.R
@@ -56,7 +56,6 @@ NULL
 #'
 genesCoexSpace <-
   function(objCOTAN, primaryMarkers, numGenesPerMarker = 25L) {
-  # TODO: output tanh of reduced coex matrix
   logThis("Calculating gene co-expression space - START", logLevel = 2L)
 
   if (TRUE) {
@@ -74,7 +73,8 @@ genesCoexSpace <-
   secondaryMarkers <- primaryMarkers
 
   for (marker in primaryMarkers) {
-    lowestPValueGenesPos <- order(pValue[, marker])[1L:numGenesPerMarker]
+    lowestPValueGenesPos <-
+      order(pValue[, marker, drop = TRUE])[1L:numGenesPerMarker]
     secondaryMarkers <- c(secondaryMarkers,
                           getGenes(objCOTAN)[lowestPValueGenesPos])
   }
@@ -86,12 +86,12 @@ genesCoexSpace <-
   logThis(paste("Number of selected secondary markers:",
                 length(secondaryMarkers)), logLevel = 1L)
 
-  pValue <- pValue[secondaryMarkers, ]
+  pValue <- pValue[secondaryMarkers, , drop = FALSE]
 
   rankGenes <- data.frame()
   for (marker in primaryMarkers) {
     rankGenes <- setColumnInDF(rankGenes,
-                               colToSet = rank(pValue[, marker],
+                               colToSet = rank(pValue[, marker, drop = TRUE],
                                                ties.method = "first"),
                                colName = marker,
                                rowNames = secondaryMarkers)

--- a/tests/testthat/test-establishGenesClusters.R
+++ b/tests/testthat/test-establishGenesClusters.R
@@ -6,6 +6,18 @@ test_that("Establish genes clusters", {
   objCOTAN <- proceedToCoex(objCOTAN, cores = 6L,
                             optimizeForSpeed = FALSE, saveObj = FALSE)
 
+  c(secondaryMarkers, GCS, rankGenes) %<-%
+    genesCoexSpace(objCOTAN = objCOTAN,
+                   primaryMarkers = c("g-000300"),
+                   numGenesPerMarker = 5L)
+
+  expect_gt(length(secondaryMarkers), 1L)
+  expect_equal(colnames(rankGenes), c("g-000300"), ignore_attr = TRUE)
+  expect_identical(rownames(rankGenes), secondaryMarkers)
+
+  expect_identical(colnames(GCS), secondaryMarkers)
+  expect_lte(max(abs(GCS)), 1L)
+
   groupMarkers <- list(G1 = c("g-000010", "g-000020", "g-000030"),
                        G2 = c("g-000300", "g-000330"),
                        G3 = c("g-000510", "g-000530", "g-000550",


### PR DESCRIPTION
Now `primaryMarkers` argument can be just a single gene