### PR TITLE
Fixed minor bug in AdvancedGDIUniformityCheck

### DIFF
--- a/R/UTCheckers.R
+++ b/R/UTCheckers.R
@@ -259,7 +259,7 @@ setMethod(
     thirdCheckOK <- FALSE
     if (cCheck3@thresholdRank > 0L) {
       thirdCheckOK <-
-        (cCheck3@thresholdRank <= cCheck3@maxRankBeyond)
+        (cCheck3@thresholdRank < cCheck3@maxRankBeyond)
     } else if (is.finite(cCheck3@quantileAtRank)) {
       thirdCheckOK <-
         (cCheck3@quantileAtRank <= cCheck3@GDIThreshold)


### PR DESCRIPTION
The third check tested that the rank of the threshold was not greater than given input, but this implies that ranked GDI value could exceed given threshold as if rank were 1 greater (unlike given specifications)