### PR TITLE
Clean parameters for `proceedToCoex()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+Added possibility to specify `clean()` thresholds in the functions
+`proceedToCoex()` and `automaticCOTANObjectCreation()`
+
 ## 2.7.1
 
 Improved function `clustersMarkersHeatmapPlot()`: now its shows a column for

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -2,7 +2,10 @@
 setGeneric(
   "proceedToCoex",
   function(objCOTAN, calcCoex = TRUE, optimizeForSpeed = TRUE,
-           deviceStr = "cuda", cores = 1L, saveObj = TRUE, outDir = ".") {
+           deviceStr = "cuda", cores = 1L,
+           cellsCutoff = 0.003, genesCutoff = 0.002,
+           cellsThreshold = 0.99, genesThreshold = 0.99,
+           saveObj = TRUE, outDir = ".") {
     standardGeneric("proceedToCoex")
   }
 )

--- a/R/automaticCOTANObjectCreation.R
+++ b/R/automaticCOTANObjectCreation.R
@@ -16,6 +16,18 @@
 #'   `"cuda"` to use the system *GPUs* or something like `"cuda:0"` to restrict
 #'   to a specific device
 #' @param cores number of cores to use. Default is 1.
+#' @param cellsCutoff `clean()` will delete from the `raw` data any gene that is
+#'   expressed in less cells than threshold times the total number of cells.
+#'   Default cutoff is \eqn{0.003 \; (0.3\%)}
+#' @param genesCutoff `clean()` will delete from the `raw` data any cell that is
+#'   expressing less genes than threshold times the total number of genes.
+#'   Default cutoff is \eqn{0.002 \; (0.2\%)}
+#' @param cellsThreshold any gene that is expressed in more cells than threshold
+#'   times the total number of cells will be marked as **fully-expressed**.
+#'   Default threshold is \eqn{0.99 \; (99.0\%)}
+#' @param genesThreshold any cell that is expressing more genes than threshold
+#'   times the total number of genes will be marked as **fully-expressing**.
+#'   Default threshold is \eqn{0.99 \; (99.0\%)}
 #' @param saveObj Boolean flag; when `TRUE` saves intermediate analyses and
 #'   plots to file
 #' @param outDir an existing directory for the analysis output.
@@ -63,12 +75,16 @@ setMethod(
   "proceedToCoex",
   "COTAN",
   function(objCOTAN, calcCoex = TRUE, optimizeForSpeed = TRUE,
-           deviceStr = "cuda", cores = 1L, saveObj = TRUE, outDir = ".") {
+           deviceStr = "cuda", cores = 1L,
+           cellsCutoff = 0.003, genesCutoff = 0.002,
+           cellsThreshold = 0.99, genesThreshold = 0.99,
+           saveObj = TRUE, outDir = ".") {
     startTimeAll <- Sys.time()
 
     logThis("Cotan analysis functions started", logLevel = 1L)
 
-    objCOTAN <- clean(objCOTAN)
+    objCOTAN <- clean(objCOTAN, cellsCutoff, genesCutoff,
+                      cellsThreshold, genesThreshold)
 
     if (isTRUE(saveObj)) tryCatch({
       if (!dir.exists(outDir)) {
@@ -205,6 +221,18 @@ setMethod(
 #'   `"cuda"` to use the system *GPUs* or something like `"cuda:0"` to restrict
 #'   to a specific device
 #' @param cores number of cores to use. Default is 1.
+#' @param cellsCutoff `clean()` will delete from the `raw` data any gene that is
+#'   expressed in less cells than threshold times the total number of cells.
+#'   Default cutoff is \eqn{0.003 \; (0.3\%)}
+#' @param genesCutoff `clean()` will delete from the `raw` data any cell that is
+#'   expressing less genes than threshold times the total number of genes.
+#'   Default cutoff is \eqn{0.002 \; (0.2\%)}
+#' @param cellsThreshold any gene that is expressed in more cells than threshold
+#'   times the total number of cells will be marked as **fully-expressed**.
+#'   Default threshold is \eqn{0.99 \; (99.0\%)}
+#' @param genesThreshold any cell that is expressing more genes than threshold
+#'   times the total number of genes will be marked as **fully-expressing**.
+#'   Default threshold is \eqn{0.99 \; (99.0\%)}
 #' @param saveObj Boolean flag; when `TRUE` saves intermediate analyses and
 #'   plots to file
 #' @param outDir an existing directory for the analysis output.
@@ -232,8 +260,11 @@ setMethod(
 
 automaticCOTANObjectCreation <-
   function(raw, GEO, sequencingMethod, sampleCondition,
-           calcCoex = TRUE, optimizeForSpeed = TRUE, deviceStr = "cuda",
-           cores = 1L, saveObj = TRUE, outDir = ".") {
+           calcCoex = TRUE, optimizeForSpeed = TRUE,
+           deviceStr = "cuda", cores = 1L,
+           cellsCutoff = 0.003, genesCutoff = 0.002,
+           cellsThreshold = 0.99, genesThreshold = 0.99,
+           saveObj = TRUE, outDir = ".") {
 
     objCOTAN <- COTAN(raw = raw)
     objCOTAN <- initializeMetaDataset(objCOTAN, GEO = GEO,
@@ -246,5 +277,7 @@ automaticCOTANObjectCreation <-
     return(proceedToCoex(objCOTAN, calcCoex = calcCoex,
                          optimizeForSpeed = optimizeForSpeed,
                          deviceStr = deviceStr, cores = cores,
+                         cellsCutoff, genesCutoff,
+                         cellsThreshold, genesThreshold,
                          saveObj = saveObj, outDir = outDir))
   }

--- a/man/COTAN_ObjectCreation.Rd
+++ b/man/COTAN_ObjectCreation.Rd
@@ -16,6 +16,10 @@ COTAN(raw = "ANY")
   optimizeForSpeed = TRUE,
   deviceStr = "cuda",
   cores = 1L,
+  cellsCutoff = 0.003,
+  genesCutoff = 0.002,
+  cellsThreshold = 0.99,
+  genesThreshold = 0.99,
   saveObj = TRUE,
   outDir = "."
 )
@@ -29,6 +33,10 @@ automaticCOTANObjectCreation(
   optimizeForSpeed = TRUE,
   deviceStr = "cuda",
   cores = 1L,
+  cellsCutoff = 0.003,
+  genesCutoff = 0.002,
+  cellsThreshold = 0.99,
+  genesThreshold = 0.99,
   saveObj = TRUE,
   outDir = "."
 )
@@ -51,6 +59,22 @@ the calculations. Possible values are \code{"cpu"} to us the system \emph{CPU},
 to a specific device}
 
 \item{cores}{number of cores to use. Default is 1.}
+
+\item{cellsCutoff}{\code{clean()} will delete from the \code{raw} data any gene that is
+expressed in less cells than threshold times the total number of cells.
+Default cutoff is \eqn{0.003 \; (0.3\%)}}
+
+\item{genesCutoff}{\code{clean()} will delete from the \code{raw} data any cell that is
+expressing less genes than threshold times the total number of genes.
+Default cutoff is \eqn{0.002 \; (0.2\%)}}
+
+\item{cellsThreshold}{any gene that is expressed in more cells than threshold
+times the total number of cells will be marked as \strong{fully-expressed}.
+Default threshold is \eqn{0.99 \; (99.0\%)}}
+
+\item{genesThreshold}{any cell that is expressing more genes than threshold
+times the total number of genes will be marked as \strong{fully-expressing}.
+Default threshold is \eqn{0.99 \; (99.0\%)}}
 
 \item{saveObj}{Boolean flag; when \code{TRUE} saves intermediate analyses and
 plots to file}


### PR DESCRIPTION
Added possibility to specify `clean()` thresholds in the functions `proceedToCoex()` and `automaticCOTANObjectCreation()`