### PR TITLE
Made more conveninent checkers' conversions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+Added checker class type to the data.frame obtained after conversion.
+It will make loading checker results from file easier.
+
+Improved README.md with stable links to devel and release versions in
+BioConductor
+
 ## 2.7.5
 
 Solved issue with use of `parallelDist::parDist()` by allowing a fall-back to

--- a/R/clean-plot.R
+++ b/R/clean-plot.R
@@ -80,7 +80,8 @@ cleanPlots <- function(objCOTAN, includePCA = TRUE) {
     assert_that(identical(rownames(pcaCells), getCells(objCOTAN)),
                 msg = "Issues with pca output")
 
-    distCells <- calcDist(scale(pcaCells), method = "euclidean") # mahlanobis
+    distCells <- scale(pcaCells)
+    distCells <- calcDist(distCells, method = "euclidean") # mahlanobis
 
     pcaCells <- as.data.frame(pcaCells)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # COTAN v2
 
-A Comprehensive and Versatile Framework for Single-Cell Gene Co-Expression Studies and Cell Type Identification
+This package provides a *comprehensive* and *versatile* framework for single-cell **gene Co-Expression** studies and cell type identification.
 
 ## About
 
-The estimation of gene co-expression in single-cell RNA sequencing (scRNA-seq) is a critical step in the analysis of scRNA-seq data. The low efficiency of scRNA-seq methodologies makes sensitive computational approaches crucial to accurately infer transcription profiles in a cell population.
+The estimation of gene *co-expression* in single-cell RNA sequencing (scRNA-seq) is a critical step in the analysis of scRNA-seq data. The low efficiency of scRNA-seq methodologies makes sensitive computational approaches crucial to accurately infer transcription profiles in a cell population.
 
 `COTAN` is a statistical and computational method that analyzes the co-expression of gene pairs at the single-cell level. It employs an innovative mathematical model that leads to a generalized contingency table framework. `COTAN` relies on the zero Unique Molecular Identifier (`UMI`) counts distribution instead of focusing on positive counts to evaluate or extract different scores and information for gene correlation studies and gene or cell clustering.
 
@@ -24,7 +24,12 @@ The first link shows how to handle the genes' clustering while the second shows 
 
 ## Installation
 
-The production version can be installed via Bioconductor [COTAN for Bioconductor 3.20](https://bioconductor.org/packages/3.20/bioc/html/COTAN.html "Production version"){.uri}, while a stable development version can be found [COTAN for Bioconductor 3.21](https://bioconductor.org/packages/3.21/bioc/html/COTAN.html%20%22Development%20version%22){.uri}.
+| Build | Status |
+|----|----|
+| Bioc-release | [![](https://bioconductor.org/shields/build/release/bioc/COTAN.svg)](https://bioconductor.org/checkResults/release/bioc-LATEST/COTAN) |
+| Bioc-devel | [![](https://bioconductor.org/shields/build/devel/bioc/COTAN.svg)](https://bioconductor.org/checkResults/devel/bioc-LATEST/COTAN/) |
+
+Check out the user guide on the [Bioconductor landing page](https://bioconductor.org/packages/devel/bioc/html/COTAN.html) for more details.
 
 The latest snapshot can be installed directly as `R` package using `devtools`. The installation was tested on *Linux*, *Windows* and *Mac* but please note that due to lack of multi-core support under *Windows* it might run slower. `devtools::install_github("seriph78/COTAN")`
 

--- a/man/UniformTranscriptCheckers.Rd
+++ b/man/UniformTranscriptCheckers.Rd
@@ -29,7 +29,7 @@
 
 checkersToDF(checkers)
 
-dfToCheckers(df, checkerClass)
+dfToCheckers(df, checkerClass = "")
 
 \S4method{getCheckerThreshold}{SimpleGDIUniformityCheck}(checker)
 

--- a/tests/testthat/test-mergeUniformCellsClusters.R
+++ b/tests/testthat/test-mergeUniformCellsClusters.R
@@ -103,7 +103,7 @@ test_that("Merge Uniform Cells Clusters", {
                                    "all_check_results_4.csv"),
                          header = TRUE, row.names = 1L)
   expect_identical(nrow(allCheckDF),  7L)
-  expect_identical(ncol(allCheckDF), 34L)
+  expect_identical(ncol(allCheckDF), 35L)
 
   allCheckRes <- dfToCheckers(allCheckDF, "AdvancedGDIUniformityCheck")
 


### PR DESCRIPTION
Now it is possible to avoid specifying the checker `class-type` when converting from a `data.frame` representing a checker.