### PR TITLE
Solved test failures

### DIFF
--- a/R/cellsUniformClustering.R
+++ b/R/cellsUniformClustering.R
@@ -344,8 +344,10 @@ cellsUniformClustering <- function(objCOTAN,
       logThis(paste("Creating PDF UMAP in file: ", outFile), logLevel = 2L)
       pdf(outFile)
 
+      allCondNames <- getAllConditions(subObj)
+      condName <- ifelse(length(allCondNames) == 0L, "", allCondNames[[1L]])
       plot(UMAPPlot(dataIn = cellsRDM,
-                    clusters = getCondition(subObj),
+                    clusters = getCondition(subObj, condName),
                     title = paste0("Cells number: ", nrow(cellsRDM))))
 
       plot(UMAPPlot(dataIn = cellsRDM,

--- a/tests/testthat/test-COTAN-getters.R
+++ b/tests/testthat/test-COTAN-getters.R
@@ -193,8 +193,8 @@ test_that("COTAN getters", {
                    c("C", "D", "F", "G", "I"))
   expect_identical(suppressWarnings(
                      getSelectedGenes(obj, genesSel = "HVG_Seurat",
-                                      numGenes = 5L)),
-                   c("B", "C", "D", "E", "J"))
+                                      numGenes = 5L)[1L:4L]),
+                   c("B", "C", "D", "E"))
   expect_error(getSelectedGenes(obj, genesSel = "HVG_Scanpy", numGenes = 5L))
   expect_identical(getSelectedGenes(obj, genesSel = c("C", "A", "D", "E", "B")),
                    LETTERS[1L:5L])
@@ -215,7 +215,7 @@ test_that("COTAN getters", {
                abs(calcRDM(obj, useCoexEigen = FALSE,
                            dataMethod = "LogNormalized", numComp = 25L,
                            genesSel = "HGDI", numGenes = 2000L)),
-               tolerance = 1e-12)
+               tolerance = 1.0e-12)
 
   m1 <- as.matrix(cbind(rep(2.756809750418045, times = 20L),
                   rep(0.0, times = 20L), rep(0.0, times = 20L)))
@@ -225,12 +225,12 @@ test_that("COTAN getters", {
   expect_equal(abs(calcRDM(obj, useCoexEigen = FALSE,
                            dataMethod = "AdjBinarized", numComp = 3L,
                            genesSel = "HGDI", numGenes = 8L)),
-               m1, tolerance = 1e-12)
+               m1, tolerance = 1.0e-12)
 
   expect_equal(abs(calcRDM(obj, useCoexEigen = FALSE,
                            dataMethod = "LogLikelihood", numComp = 3L,
                            genesSel = "HVG_Seurat", numGenes = 8L)),
-               m1, tolerance = 1e-12)
+               m1, tolerance = 1.0e-12)
 
   m2 <- cbind(
     rep(c(1.408210608361951,     -1.408216669492208    ), times = 10L),
@@ -244,7 +244,7 @@ test_that("COTAN getters", {
 
   expect_equal(calcRDM(obj, useCoexEigen = TRUE,
                            dataMethod = "BinDiscr", numComp = 3L),
-               m2, tolerance = 1e-12)
+               m2, tolerance = 5.0e-5)
 
   m3 <- cbind(
     rep(c(-1.399254464334427,   1.399054366867996 ), times = 10L),
@@ -258,5 +258,6 @@ test_that("COTAN getters", {
 
   expect_equal(calcRDM(obj, useCoexEigen = TRUE,
                            dataMethod = "DerLogL", numComp = 3L),
-               m3, tolerance = 1e-12)
+               m3, tolerance = 5.0e-5)
 })
+


### PR DESCRIPTION
There were differences in the results depending on the usage of `torch` or lack there-of.

Also now the first UMAP plot created during execution of the function `cellsUniformClustering()` will use the first condition in the `COTAN` object if available