### PR TITLE
Bugfix/avoid split clust early termination

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+Improved function `cellsUniformClustering()` mechanism in case of larger
+datasets when resolution ceiling was causing unnecessary slowdown and
+in cases early termination too
+
 ## 2.9.4
 
 Solved minor issue with `maxIterations` argument in the function

--- a/R/COTAN-getters.R
+++ b/R/COTAN-getters.R
@@ -1136,7 +1136,7 @@ setMethod(
 #' @examples
 #' data("test.dataset")
 #' objCOTAN <- COTAN(raw = test.dataset)
-#' objCOTAN <- proceedToCoex(objCOTAN, cores = 6L, calcCoex = FALSE,
+#' objCOTAN <- proceedToCoex(objCOTAN, cores = 6L, calcCoex = TRUE,
 #'                           optimizeForSpeed = TRUE, saveObj = FALSE)
 #'
 #' data("test.dataset.clusters1")
@@ -1164,7 +1164,9 @@ setMethod(
 #' umapPlot2 <- UMAPPlot(lfcDF, clusters = geneClusters)
 #' plot(umapPlot2)
 #'
-#' objCOTAN <- estimateNuLinearByCluster(objCOTAN, clusters = clusters)
+#' if (FALSE) {
+#'   objCOTAN <- estimateNuLinearByCluster(objCOTAN, clusters = clusters)
+#' }
 #'
 #' clSummaryPlotAndData <-
 #'   clustersSummaryPlot(objCOTAN, clName = "first_clusterization",
@@ -1178,24 +1180,28 @@ setMethod(
 #' clusterizations <- getClusterizations(objCOTAN, dropNoCoex = TRUE)
 #' stopifnot(length(clusterizations) == 1)
 #'
-#' cellsUmapPlotAndDF <- cellsUMAPPlot(objCOTAN, dataMethod = "LogNormalized",
-#'                                     clName = "first_clusterization",
-#'                                     genesSel = "HVG_Seurat")
+#' cellsUmapPlotAndDF <- cellsUMAPPlot(objCOTAN, dataMethod = "LogLikelihood",
+#'                                     useCoexEigen = TRUE, numComp = 25L,
+#'                                     clName = "first_clusterization")
 #' plot(cellsUmapPlotAndDF[["plot"]])
 #'
 #' enrichment <- geneSetEnrichment(clustersCoex = coexDF,
 #'                                 groupMarkers = groupMarkers)
 #'
 #' clHeatmapPlotAndData <- clustersMarkersHeatmapPlot(objCOTAN, groupMarkers)
+#' clHeatmapPlotAndData[["heatmapPlot"]]
 #'
 #' conditions <- as.integer(substring(getCells(objCOTAN), 3L))
 #' conditions <- factor(ifelse(conditions <= 600, "L", "H"))
 #' names(conditions) <- getCells(objCOTAN)
 #'
+#' objCOTAN <- addCondition(objCOTAN, condName = "High/Low",
+#'                          conditions = conditions)
+#'
 #' clHeatmapPlotAndData2 <-
 #'   clustersMarkersHeatmapPlot(objCOTAN, groupMarkers, kCuts = 2,
-#'                              condNameList = list("High/Low"),
-#'                              conditionsList = list(conditions))
+#'                              condNameList = list("High/Low"))
+#' clHeatmapPlotAndData2[["heatmapPlot"]]
 #'
 #' @rdname HandlingClusterizations
 #'

--- a/R/cellsUniformClustering.R
+++ b/R/cellsUniformClustering.R
@@ -578,8 +578,6 @@ cellsUniformClustering <- function(objCOTAN,
     })
   names(allCheckResults) <- permMap[names(allCheckResults)]
 
-  outputList <- list("clusters" = factor(outputClusters), "coex" = outputCoexDF)
-
   if (isTRUE(saveObj)) tryCatch({
       outFile <- file.path(outDirCond, "split_check_results.csv")
       write.csv(checkersToDF(allCheckResults), file = outFile, na = "NaN")
@@ -595,5 +593,5 @@ cellsUniformClustering <- function(objCOTAN,
 
   logThis("Creating cells' uniform clustering: DONE", logLevel = 2L)
 
-  return(outputList)
+  return(list("clusters" = outputClusters, "coex" = outputCoexDF))
 }

--- a/R/cellsUniformClustering.R
+++ b/R/cellsUniformClustering.R
@@ -26,6 +26,8 @@ NULL
 #' @param rawData The raw counts
 #' @param initialResolution The resolution to use at first in the
 #'   *clusterization* algorithm
+#' @param resolutionStep How much to increase the resolution to retry a
+#'   *clusterization* that does not respect the `minNumClusters`
 #' @param minNumClusters The minimum number of *clusters* expected from this
 #'   *clusterization*. In cases it is not reached, it will increase the
 #'   resolution of the *clusterization*
@@ -58,7 +60,9 @@ NULL
 #'
 
 seuratClustering <- function(objCOTAN,
-                             initialResolution, minNumClusters,
+                             initialResolution = 0.8,
+                             resolutionStep = 0.5,
+                             minNumClusters = 1L,
                              useCoexEigen, dataMethod,
                              genesSel, numGenes,
                              numReducedComp) {
@@ -90,8 +94,7 @@ seuratClustering <- function(objCOTAN,
     srat <- FindNeighbors(srat, dims = seq_len(numReducedComp))
 
     resolution <- initialResolution
-    resolutionStep <- 0.5
-    maxResolution <- initialResolution + 10.0 * resolutionStep
+    maxResolution <- initialResolution + 30.0 * resolutionStep
 
     seuratClusters <- NULL
     usedMaxResolution <- FALSE
@@ -281,6 +284,7 @@ cellsUniformClustering <- function(objCOTAN,
 
   iter <- initialIteration - 1L
   iterReset <- -1L
+  resolutionStep <- 0.5
   numClustersToRecluster <- 0L
   srat <- NULL
   allCheckResults <- list()
@@ -313,7 +317,8 @@ cellsUniformClustering <- function(objCOTAN,
     cellsToDrop <- getCells(objCOTAN)[!is.na(outputClusters)]
     subObj <- dropGenesCells(objCOTAN, cells = cellsToDrop)
 
-    if (str_equal(genesSel, "HGDI") || isTRUE(useCoexEigen)) {
+    if ((str_equal(genesSel, "HGDI") || isTRUE(useCoexEigen)) &&
+      !isCoexAvailable(subObj)) {
       subObj <-
         proceedToCoex(subObj, calcCoex = TRUE, cores = cores,
                       optimizeForSpeed = optimizeForSpeed,
@@ -324,7 +329,9 @@ cellsUniformClustering <- function(objCOTAN,
     #Step 1
     minNumClusters <- floor(1.2 * numClustersToRecluster) + 1L
     c(testClusters, cellsRDM, resolution, usedMaxResolution) %<-%
-      seuratClustering(subObj, initialResolution = initialResolution,
+      seuratClustering(subObj,
+                       initialResolution = initialResolution,
+                       resolutionStep = resolutionStep,
                        minNumClusters = minNumClusters,
                        useCoexEigen = useCoexEigen,
                        dataMethod = dataMethod,
@@ -338,6 +345,11 @@ cellsUniformClustering <- function(objCOTAN,
       break
     }
 
+    if (iter == initialIteration && !is_null(initialClusters)) {
+      logThis("Using passed in clusterization", logLevel = 3L)
+      testClusters <- asClusterization(initialClusters, getCells(objCOTAN))
+    }
+
     ## print umap graph
     if (isTRUE(saveObj)) tryCatch({
       outFile <- file.path(splitOutDir, paste0("pdf_umap_", iter, ".pdf"))
@@ -345,15 +357,16 @@ cellsUniformClustering <- function(objCOTAN,
       pdf(outFile)
 
       allCondNames <- getAllConditions(subObj)
-      condName <- ifelse(length(allCondNames) == 0L, "", allCondNames[[1L]])
-      plot(UMAPPlot(dataIn = cellsRDM,
-                    clusters = getCondition(subObj, condName),
-                    title = paste0("Cells number: ", nrow(cellsRDM))))
+      condName <- ifelse(length(allCondNames) == 0L, "",
+                         allCondNames[[length(allCondNames)]])
+      title <- paste0("Cells number: ", nrow(cellsRDM))
+      plot(UMAPPlot(dataIn = cellsRDM, title = title,
+                    clusters = getCondition(subObj, condName)))
 
-      plot(UMAPPlot(dataIn = cellsRDM,
-                    clusters = testClusters,
-                    title = paste0("Cells number: ", nrow(cellsRDM), "\n",
-                                   "Cl. resolution: ", resolution)))
+      title <- paste0(title, "\nCl. resolution: ", resolution,
+                      ifelse(isTRUE(usedMaxResolution), " [max]", ""))
+      plot(UMAPPlot(dataIn = cellsRDM, title = title,
+                    clusters = testClusters))
     }, error = function(err) {
       logThis(paste("While saving seurat UMAP plot", err), logLevel = 1L)
     }, finally = {
@@ -371,10 +384,6 @@ cellsUniformClustering <- function(objCOTAN,
     numClustersToRecluster <- 0L
     cellsToRecluster <- vector(mode = "character")
 
-    if (iter == initialIteration && !is_null(initialClusters)) {
-      logThis("Using passed in clusterization", logLevel = 3L)
-      testClusters <- asClusterization(initialClusters, getCells(objCOTAN))
-    }
     allCells <- names(testClusters)
     testClList <- toClustersList(testClusters)
 
@@ -456,7 +465,10 @@ cellsUniformClustering <- function(objCOTAN,
       warning("In iteration '", iter, "' no uniform clusters found!")
       # Another iteration can be attempted as the minimum number of clusters
       # will be higher. This happens unless the resolution already reached
-      # its maximum. In the latter case we simply stop here.
+      # its maximum. In the latter case we simply stop here, unless some UT
+      # cluster was found. In the latter case we restart from the minimal
+      # resolution, but with larger resolution steps and try to re-cluster with
+      # no minimal number of clusters
       if (isTRUE(usedMaxResolution) || maxClusterSize < minimumUTClusterSize) {
         logThis("Max resolution reached", logLevel = 1L)
         if (iterReset != -1L) {
@@ -468,6 +480,9 @@ cellsUniformClustering <- function(objCOTAN,
                   logLevel = 2L)
           numClustersToRecluster <- 0L
           iterReset <- iter
+          if (maxClusterSize >= minimumUTClusterSize) {
+            resolutionStep <- resolutionStep + 0.3
+          }
         }
       }
     } else {
@@ -568,6 +583,10 @@ cellsUniformClustering <- function(objCOTAN,
   if (isTRUE(saveObj)) tryCatch({
       outFile <- file.path(outDirCond, "split_check_results.csv")
       write.csv(checkersToDF(allCheckResults), file = outFile, na = "NaN")
+
+      outFile <- file.path(outDirCond, "split_clusterization.csv")
+      write.csv(as.data.frame(list("split" = outputClusters)),
+                file = outFile, na = "NaN")
     },
     error = function(err) {
       logThis(paste("While saving results csv", err), logLevel = 1L)

--- a/R/mergeUniformCellsClusters.R
+++ b/R/mergeUniformCellsClusters.R
@@ -590,6 +590,10 @@ mergeUniformCellsClusters <- function(objCOTAN,
   if (isTRUE(saveObj)) tryCatch({
     outFile <- file.path(outDirCond, "merge_check_results.csv")
     write.csv(checkersToDF(allCheckResults), file = outFile, na = "NaN")
+
+    outFile <- file.path(outDirCond, "merge_clusterization.csv")
+    write.csv(as.data.frame(list("merge" = outputClusters)),
+              file = outFile, na = "NaN")
   })
 
   logThis("Merging cells' uniform clustering: DONE", logLevel = 2L)

--- a/man/HandlingClusterizations.Rd
+++ b/man/HandlingClusterizations.Rd
@@ -519,7 +519,7 @@ according to a \emph{DEA} (or \emph{Zero-One}) based distance
 \examples{
 data("test.dataset")
 objCOTAN <- COTAN(raw = test.dataset)
-objCOTAN <- proceedToCoex(objCOTAN, cores = 6L, calcCoex = FALSE,
+objCOTAN <- proceedToCoex(objCOTAN, cores = 6L, calcCoex = TRUE,
                           optimizeForSpeed = TRUE, saveObj = FALSE)
 
 data("test.dataset.clusters1")
@@ -547,7 +547,9 @@ lfcDF <- logFoldChangeOnClusters(objCOTAN, clusters = clusters)
 umapPlot2 <- UMAPPlot(lfcDF, clusters = geneClusters)
 plot(umapPlot2)
 
-objCOTAN <- estimateNuLinearByCluster(objCOTAN, clusters = clusters)
+if (FALSE) {
+  objCOTAN <- estimateNuLinearByCluster(objCOTAN, clusters = clusters)
+}
 
 clSummaryPlotAndData <-
   clustersSummaryPlot(objCOTAN, clName = "first_clusterization",
@@ -561,24 +563,28 @@ if (FALSE) {
 clusterizations <- getClusterizations(objCOTAN, dropNoCoex = TRUE)
 stopifnot(length(clusterizations) == 1)
 
-cellsUmapPlotAndDF <- cellsUMAPPlot(objCOTAN, dataMethod = "LogNormalized",
-                                    clName = "first_clusterization",
-                                    genesSel = "HVG_Seurat")
+cellsUmapPlotAndDF <- cellsUMAPPlot(objCOTAN, dataMethod = "LogLikelihood",
+                                    useCoexEigen = TRUE, numComp = 25L,
+                                    clName = "first_clusterization")
 plot(cellsUmapPlotAndDF[["plot"]])
 
 enrichment <- geneSetEnrichment(clustersCoex = coexDF,
                                 groupMarkers = groupMarkers)
 
 clHeatmapPlotAndData <- clustersMarkersHeatmapPlot(objCOTAN, groupMarkers)
+clHeatmapPlotAndData[["heatmapPlot"]]
 
 conditions <- as.integer(substring(getCells(objCOTAN), 3L))
 conditions <- factor(ifelse(conditions <= 600, "L", "H"))
 names(conditions) <- getCells(objCOTAN)
 
+objCOTAN <- addCondition(objCOTAN, condName = "High/Low",
+                         conditions = conditions)
+
 clHeatmapPlotAndData2 <-
   clustersMarkersHeatmapPlot(objCOTAN, groupMarkers, kCuts = 2,
-                             condNameList = list("High/Low"),
-                             conditionsList = list(conditions))
+                             condNameList = list("High/Low"))
+clHeatmapPlotAndData2[["heatmapPlot"]]
 
 clName <- getClusterizationName(objCOTAN)
 

--- a/tests/testthat/test-cellsUniformClustering.R
+++ b/tests/testthat/test-cellsUniformClustering.R
@@ -48,6 +48,7 @@ test_that("Cell Uniform Clustering", {
   expect_true(file.exists(file.path(tm, "test", "reclustering",
                                     "all_check_results_1.csv")))
   expect_true(file.exists(file.path(tm, "test", "split_check_results.csv")))
+  expect_true(file.exists(file.path(tm, "test", "split_clusterization.csv")))
 
   gc()
 

--- a/tests/testthat/test-mergeUniformCellsClusters.R
+++ b/tests/testthat/test-mergeUniformCellsClusters.R
@@ -98,6 +98,7 @@ test_that("Merge Uniform Cells Clusters", {
   expect_true(file.exists(file.path(tm, "test", "leafs_merge",
                                     "all_check_results_4.csv")))
   expect_true(file.exists(file.path(tm, "test", "merge_check_results.csv")))
+  expect_true(file.exists(file.path(tm, "test", "merge_clusterization.csv")))
 
   allCheckDF <- read.csv(file.path(tm, "test", "leafs_merge",
                                    "all_check_results_4.csv"),

--- a/vignettes/Guided_tutorial_v2.Rmd
+++ b/vignettes/Guided_tutorial_v2.Rmd
@@ -22,7 +22,7 @@ knitr::opts_chunk[["set"]](
   dev = "png",
   fig.width = 6L,
   fig.height = 4L,
-  dpi = 72
+  dpi = 72L
 )
 
 ```
@@ -687,8 +687,8 @@ It is possible to plot the *clusterization* on a `UMAP` plot
 c(umapPlot, cellsRDM) %<-% cellsUMAPPlot(obj, clName = "merge2",
                                          clusters = NULL,
                                          useCoexEigen = TRUE,
-                                         dataMethod = "SignLogL",
-                                         numComp = 25L,
+                                         dataMethod = "LogLikelihood",
+                                         numComp = 50L,
                                          genesSel = "HGDI",
                                          numGenes = 200L,
                                          colors = NULL,


### PR DESCRIPTION
Now the resolution ceiling is 15.0 above the initial one and also can be increased when it gets hit hard.

Final clusterizations of functions `cellsUniformClustering()` and `mergeUniformCellsClusters()` is now dumped to `.csv` file if asked to...