### PR TITLE
Improved torch implementation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,4 @@
+Improved the `torch coex` code so to use less memory and do less calculations
 
 ## 2.9.5
 

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -5,7 +5,7 @@ setGeneric(
            deviceStr = "cuda", cores = 1L,
            cellsCutoff = 0.003, genesCutoff = 0.002,
            cellsThreshold = 0.99, genesThreshold = 0.99,
-           saveObj = TRUE, outDir = ".") {
+           saveObj = FALSE, outDir = ".") {
     standardGeneric("proceedToCoex")
   }
 )

--- a/R/COTAN-estimators.R
+++ b/R/COTAN-estimators.R
@@ -242,7 +242,7 @@ runDispSolver <- function(genesBatches, sumZeros, lambda, nu,
       threshold = threshold,
       maxIterations = maxIterations,
       mc.cores = cores,
-      mc.preschedule = FALSE)
+      mc.preschedule = TRUE)
 
     # spawned errors are stored as try-error classes
     resError <- unlist(lapply(res, inherits, "try-error"))
@@ -431,7 +431,7 @@ runNuSolver <- function(cellsBatches, sumZeros, lambda, dispersion,
       threshold = threshold,
       maxIterations = maxIterations,
       mc.cores = cores,
-      mc.preschedule = FALSE)
+      mc.preschedule = TRUE)
 
     # spawned errors are stored as try-error classes
     resError <- unlist(lapply(res, inherits, "try-error"))

--- a/R/COTAN-estimators.R
+++ b/R/COTAN-estimators.R
@@ -310,6 +310,8 @@ setMethod(
   "COTAN",
   function(objCOTAN, threshold = 0.001, cores = 1L,
            maxIterations = 100L, chunkSize = 1024L) {
+    startTime <- Sys.time()
+
     logThis("Estimate `dispersion`: START", logLevel = 2L)
 
     cores <- handleMultiCore(cores)
@@ -346,6 +348,14 @@ setMethod(
                               cores         = cores)
 
     gc()
+
+    endTime <- Sys.time()
+
+    logThis(paste("Total calculations elapsed time:",
+                  difftime(endTime, startTime, units = "secs")),
+            logLevel = 2L)
+
+    logThis("Estimate `dispersion`: DONE", logLevel = 2L)
 
     dispersion <- unlist(dispList, recursive = TRUE, use.names = FALSE)
     if (TRUE) {
@@ -488,12 +498,13 @@ setMethod(
   "COTAN",
   function(objCOTAN, threshold = 0.001, cores = 1L,
            maxIterations = 100L, chunkSize = 1024L) {
+    startTime <- Sys.time()
+
     logThis("Estimate `nu`: START", logLevel = 2L)
 
     cores <- handleMultiCore(cores)
 
     # parameters estimation
-
 
     cells <- getCells(objCOTAN)
     sumZeros <- getNumGenes(objCOTAN) - getNumExpressedGenes(objCOTAN)
@@ -534,6 +545,13 @@ setMethod(
                           cores = cores)
 
     gc()
+
+    endTime <- Sys.time()
+
+    logThis(paste("Total calculations elapsed time:",
+                  difftime(endTime, startTime, units = "secs")),
+            logLevel = 2L)
+
     logThis("Estimate `nu`: DONE", logLevel = 2L)
 
     nu <- unlist(nuList, recursive = TRUE, use.names = FALSE)
@@ -603,6 +621,8 @@ setMethod(
   function(objCOTAN, threshold = 0.001, cores = 1L,
            maxIterations = 100L, chunkSize = 1024L,
            enforceNuAverageToOne = TRUE) {
+    startTime <- Sys.time()
+
     logThis("Estimate `dispersion`/`nu`: START", logLevel = 2L)
 
     # getNu() would show a warning when no `nu` present
@@ -673,6 +693,12 @@ setMethod(
       iter <- iter + 1L
     }
 
+    endTime <- Sys.time()
+
+    logThis(paste("Total calculations elapsed time:",
+                  difftime(endTime, startTime, units = "secs")),
+            logLevel = 2L)
+
     logThis("Estimate `dispersion`/`nu`: DONE", logLevel = 2L)
 
     return(objCOTAN)
@@ -718,6 +744,8 @@ setMethod(
   function(objCOTAN, threshold = 0.001,
            maxIterations = 50L, chunkSize = 1024L,
            enforceNuAverageToOne = TRUE) {
+    startTime <- Sys.time()
+
     logThis("Estimate `dispersion`/`nu`: START", logLevel = 2L)
 
     lambda <- suppressWarnings(getLambda(objCOTAN))
@@ -776,6 +804,12 @@ setMethod(
 
     objCOTAN@metaCells <- setColumnInDF(objCOTAN@metaCells, nu,
                                         "nu", getCells(objCOTAN))
+
+    endTime <- Sys.time()
+
+    logThis(paste("Total calculations elapsed time:",
+                  difftime(endTime, startTime, units = "secs")),
+            logLevel = 2L)
 
     logThis("Estimate `dispersion`/`nu`: DONE", logLevel = 2L)
 

--- a/R/DEAOnClusters.R
+++ b/R/DEAOnClusters.R
@@ -62,6 +62,8 @@ runSingleDEA <- function(clName, cellsInList,
 #' @rdname HandlingClusterizations
 #'
 DEAOnClusters <- function(objCOTAN, clName = "", clusters = NULL) {
+  startTime <- Sys.time()
+
   logThis("Differential Expression Analysis - START", logLevel = 2L)
 
   # picks up the last clusterization if none was given
@@ -92,6 +94,12 @@ DEAOnClusters <- function(objCOTAN, clName = "", clusters = NULL) {
 
   coexDF <- as.data.frame(coexCls)
   colnames(coexDF) <- names(cellsInList)
+
+  endTime <- Sys.time()
+
+  logThis(paste("Total calculations elapsed time:",
+                difftime(endTime, startTime, units = "secs")),
+          logLevel = 2L)
 
   logThis("Differential Expression Analysis - DONE", logLevel = 2L)
 
@@ -269,6 +277,8 @@ pValueFromDEA <- function(coexDF, numCells, adjustmentMethod) {
 #'
 logFoldChangeOnClusters <- function(objCOTAN, clName = "", clusters = NULL,
                                     floorLambdaFraction = 0.05) {
+  startTime <- Sys.time()
+
   logThis("Log Fold Change Analysis - START", logLevel = 2L)
 
   # picks up the last clusterization if none was given
@@ -323,6 +333,12 @@ logFoldChangeOnClusters <- function(objCOTAN, clName = "", clusters = NULL,
                            colName = cl, rowNames = rownames(normData))
   }
   logThis("", logLevel = 1L)
+
+  endTime <- Sys.time()
+
+  logThis(paste("Total calculations elapsed time:",
+                difftime(endTime, startTime, units = "secs")),
+          logLevel = 2L)
 
   logThis("Log Fold Change Analysis - DONE", logLevel = 2L)
 

--- a/R/UMAP-plot.R
+++ b/R/UMAP-plot.R
@@ -54,7 +54,9 @@ UMAPPlot <- function(dataIn,
                      colors = NULL,
                      numNeighbors = 0L,
                      minPointsDist = NaN) {
-  logThis("UMAP plot", logLevel = 2L)
+  startTime <- Sys.time()
+
+  logThis("UMAP plot: START", logLevel = 2L)
 
   assert_that(!is_empty(rownames(dataIn)),
               msg = "UMAPPlot - input matrix must have proper row-names")
@@ -224,6 +226,14 @@ UMAPPlot <- function(dataIn,
     plot <- plot +
       theme(legend.position = "none")
   }
+
+  endTime <- Sys.time()
+
+  logThis(paste("Total calculations elapsed time:",
+                difftime(endTime, startTime, units = "secs")),
+          logLevel = 2L)
+
+  logThis("UMAP plot: DONE", logLevel = 2L)
 
   return(plot)
 }

--- a/R/automaticCOTANObjectCreation.R
+++ b/R/automaticCOTANObjectCreation.R
@@ -72,14 +72,20 @@
 setMethod(
   "proceedToCoex",
   "COTAN",
-  function(objCOTAN, calcCoex = TRUE, optimizeForSpeed = TRUE,
-           deviceStr = "cuda", cores = 1L,
-           cellsCutoff = 0.003, genesCutoff = 0.002,
-           cellsThreshold = 0.99, genesThreshold = 0.99,
-           saveObj = TRUE, outDir = ".") {
-    startTimeAll <- Sys.time()
+  function(objCOTAN,
+           calcCoex = TRUE,
+           optimizeForSpeed = TRUE,
+           deviceStr = "cuda",
+           cores = 1L,
+           cellsCutoff = 0.003,
+           genesCutoff = 0.002,
+           cellsThreshold = 0.99,
+           genesThreshold = 0.99,
+           saveObj = FALSE,
+           outDir = ".") {
+    startTime <- Sys.time()
 
-    logThis("Cotan analysis functions started", logLevel = 1L)
+    logThis("COTAN dataset analysis: START", logLevel = 1L)
 
     objCOTAN <- clean(objCOTAN, cellsCutoff, genesCutoff,
                       cellsThreshold, genesThreshold)
@@ -141,50 +147,51 @@ setMethod(
 
     gc()
 
-    analysisTime <- Sys.time()
+    startEstimTime <- Sys.time()
+    cleanTime <- difftime(startEstimTime, startTime, units = "secs")
+    logThis(paste("Dataset cleaning elapsed time:", cleanTime),
+            logLevel = 3L)
 
     objCOTAN <- estimateLambdaLinear(objCOTAN)
     objCOTAN <- estimateDispersionBisection(objCOTAN, cores = cores)
 
     gc()
 
+    startCoexTime <- Sys.time()
+    analysisTime <- difftime(startCoexTime, startEstimTime, units = "secs")
+    logThis(paste("Model parameter estimation elapsed time:", analysisTime),
+            logLevel = 3L)
+
     if (isTRUE(calcCoex)) {
-      genesCoexTime <- Sys.time()
-      analysisTime <- difftime(genesCoexTime, analysisTime, units = "secs")
+      logThis("COTAN genes' COEX estimation: START", logLevel = 2L)
 
-      logThis(paste("Only analysis elapsed time:", analysisTime), logLevel = 3L)
-
-      logThis("Cotan genes' COEX estimation started", logLevel = 1L)
       objCOTAN <- calculateCoex(objCOTAN, actOnCells = FALSE,
                                 optimizeForSpeed = optimizeForSpeed,
                                 deviceStr = deviceStr)
 
-      gc()
-
-      endTime <- Sys.time()
-
-      genesCoexTime <- difftime(endTime, genesCoexTime, units = "secs")
-
-      logThis(paste("Only genes' COEX elapsed time:", genesCoexTime),
-              logLevel = 3L)
     } else {
-      logThis("Cotan genes' COEX estimation not requested", logLevel = 2L)
-
-      genesCoexTime <- 0.0
-
-      gc()
-
-      endTime <- Sys.time()
+      logThis("COTAN genes' COEX estimation not requested", logLevel = 2L)
     }
+    
+    gc()
 
-    allTime <- difftime(endTime, startTimeAll, units = "secs")
-    logThis(paste("Total elapsed time:", allTime), logLevel = 3L)
+    endTime <- Sys.time()
+    genesCoexTime <- difftime(endTime, startCoexTime, units = "secs")
+    logThis(paste("Only genes' COEX elapsed time:", genesCoexTime),
+            logLevel = 3L)
+
+    totalTime <- difftime(endTime, startTime, units = "secs")
+    logThis(paste("Dataset analysis elapsed time:", totalTime), logLevel = 3L)
+
+    logThis("COTAN dataset analysis: DONE", logLevel = 1L)
 
     if (saveObj) {
-      utils::write.csv(data.frame("type"  = c("tot_time",
+      utils::write.csv(data.frame("type"  = c("total_time",
+                                              "clean_time",
                                               "analysis_time",
                                               "genes_coex_time"),
-                                  "times" = c(as.numeric(allTime),
+                                  "times" = c(as.numeric(totalTime),
+                                              as.numeric(cleanTime),
                                               as.numeric(analysisTime),
                                               as.numeric(genesCoexTime)),
                                   "n.cells" = getNumCells(objCOTAN),
@@ -196,6 +203,7 @@ setMethod(
               logLevel = 1L)
       saveRDS(objCOTAN, file = file.path(outDir, paste0(cond, ".cotan.RDS")))
     }
+
 
     return(objCOTAN)
   }
@@ -257,14 +265,20 @@ setMethod(
 #'
 #' @rdname COTAN_ObjectCreation
 
-automaticCOTANObjectCreation <-
-  function(raw, GEO, sequencingMethod, sampleCondition,
-           calcCoex = TRUE, optimizeForSpeed = TRUE,
-           deviceStr = "cuda", cores = 1L,
-           cellsCutoff = 0.003, genesCutoff = 0.002,
-           cellsThreshold = 0.99, genesThreshold = 0.99,
-           saveObj = TRUE, outDir = ".") {
-
+automaticCOTANObjectCreation <- function(raw,
+                                         GEO,
+                                         sequencingMethod,
+                                         sampleCondition,
+                                         calcCoex = TRUE,
+                                         optimizeForSpeed = TRUE,
+                                         deviceStr = "cuda",
+                                         cores = 1L,
+                                         cellsCutoff = 0.003,
+                                         genesCutoff = 0.002,
+                                         cellsThreshold = 0.99,
+                                         genesThreshold = 0.99,
+                                         saveObj = FALSE,
+                                         outDir = ".") {
     objCOTAN <- COTAN(raw = raw)
     objCOTAN <- initializeMetaDataset(objCOTAN, GEO = GEO,
                                       sequencingMethod = sequencingMethod,
@@ -273,10 +287,17 @@ automaticCOTANObjectCreation <-
     logThis(paste0("Condition ", sampleCondition), logLevel = 2L)
     logThis(paste("n cells", getNumCells(objCOTAN)), logLevel = 2L)
 
-    return(proceedToCoex(objCOTAN, calcCoex = calcCoex,
-                         optimizeForSpeed = optimizeForSpeed,
-                         deviceStr = deviceStr, cores = cores,
-                         cellsCutoff, genesCutoff,
-                         cellsThreshold, genesThreshold,
-                         saveObj = saveObj, outDir = outDir))
+    objCOTAN <- proceedToCoex(objCOTAN,
+                              calcCoex = calcCoex,
+                              optimizeForSpeed = optimizeForSpeed,
+                              deviceStr = deviceStr,
+                              cores = cores,
+                              cellsCutoff = cellsCutoff,
+                              genesCutoff = genesCutoff,
+                              cellsThreshold = cellsThreshold,
+                              genesThreshold = genesThreshold,
+                              saveObj = saveObj,
+                              outDir = outDir)
+
+    return(objCOTAN)
   }

--- a/R/calculateCoex-method.R
+++ b/R/calculateCoex-method.R
@@ -1134,6 +1134,10 @@ calculateCoex_Torch <- function(objCOTAN, returnPPFract, deviceStr) {
   assert_that(!is_empty(nu),
               msg = "`nu` must not be empty, estimate it")
 
+  disp <- suppressWarnings(getDispersion(objCOTAN))
+  assert_that(!is_empty(disp),
+              msg = "`dispersion` must not be empty, estimate it")
+
   # Build all three in dtype_calc:
   lambda_t <- torch::torch_tensor(lambda, device = device, dtype = dType)
   nu_t     <- torch::torch_tensor(nu,     device = device, dtype = dType)

--- a/R/calculateCoex-method.R
+++ b/R/calculateCoex-method.R
@@ -1134,10 +1134,6 @@ calculateCoex_Torch <- function(objCOTAN, returnPPFract, deviceStr) {
   assert_that(!is_empty(nu),
               msg = "`nu` must not be empty, estimate it")
 
-  disp <- suppressWarnings(getDispersion(objCOTAN))
-  assert_that(!is_empty(disp),
-              msg = "`dispersion` must not be empty, estimate it")
-
   # Build all three in dtype_calc:
   lambda_t <- torch::torch_tensor(lambda, device = device, dtype = dType)
   nu_t     <- torch::torch_tensor(nu,     device = device, dtype = dType)
@@ -1147,6 +1143,8 @@ calculateCoex_Torch <- function(objCOTAN, returnPPFract, deviceStr) {
   rm(lambda, nu, disp)
 
   expectedYY <- probOne(lambda_t, nu_t, disp_t)
+
+  rm(lambda_t, nu_t, disp_t)
 
   expectedY <- torch::torch_sum(expectedYY, 1L, dtype = dType)
 

--- a/R/cellsUniformClustering.R
+++ b/R/cellsUniformClustering.R
@@ -71,6 +71,8 @@ seuratClustering <- function(objCOTAN,
                              numReducedComp,
                              cores = 1L, chunkSize = 1024L) {
   tryCatch({
+    startTime <- Sys.time()
+
     logThis("Creating new clusterization: START", logLevel = 2L)
 
     assert_that(numReducedComp <= getNumGenes(objCOTAN))
@@ -126,6 +128,12 @@ seuratClustering <- function(objCOTAN,
     }
 
     logThis(paste("Used resolution for Seurat clusterization is:", resolution),
+            logLevel = 2L)
+
+    endTime <- Sys.time()
+
+    logThis(paste("Total calculations elapsed time:",
+                  difftime(endTime, startTime, units = "secs")),
             logLevel = 2L)
 
     logThis("Creating new clusterization: DONE", logLevel = 2L)
@@ -261,6 +269,8 @@ cellsUniformClustering <- function(objCOTAN,
                                    initialIteration = 1L,
                                    saveObj = TRUE,
                                    outDir = ".") {
+  startTime <- Sys.time()
+
   logThis("Creating cells' uniform clustering: START", logLevel = 2L)
 
   assert_that(estimatorsAreReady(objCOTAN),
@@ -311,6 +321,7 @@ cellsUniformClustering <- function(objCOTAN,
 
   repeat {
     iter <- iter + 1L
+    startLoopTime <- Sys.time()
 
     logThis(paste0("In iteration ", iter, " "), logLevel = 1L, appendLF = FALSE)
     logThis(paste("the number of cells to re-cluster is",
@@ -535,6 +546,12 @@ cellsUniformClustering <- function(objCOTAN,
 
     rm(cellsToRecluster)
     gc()
+
+    endLoopTime <- Sys.time()
+
+    logThis(paste("Loop calculations elapsed time:",
+                  difftime(endLoopTime, startLoopTime, units = "secs")),
+            logLevel = 2L)
   } # End repeat
 
   logThis(paste("The final raw clusterization contains [",
@@ -595,6 +612,12 @@ cellsUniformClustering <- function(objCOTAN,
       logThis(paste("While saving results csv", err), logLevel = 1L)
     }
   )
+
+  endTime <- Sys.time()
+
+  logThis(paste("Total calculations elapsed time:",
+                difftime(endTime, startTime, units = "secs")),
+          logLevel = 2L)
 
   logThis("Creating cells' uniform clustering: DONE", logLevel = 2L)
 

--- a/R/clean-plot.R
+++ b/R/clean-plot.R
@@ -74,12 +74,13 @@
 #' @rdname RawDataCleaning
 #'
 cleanPlots <- function(objCOTAN, includePCA = TRUE) {
+  startTime <- Sys.time()
+  logThis("Clean plots: START", logLevel = 2L)
+
   if (isTRUE(includePCA)) {
     logThis("PCA: START", logLevel = 2L)
 
     nuNormData <- getNuNormData(objCOTAN)
-
-    logThis("Elaborating PCA - START", logLevel = 3L)
 
     # re-scale so that all the genes have mean 0.0 and stdev 1.0
     cellsRDM <- runPCA(x = t(nuNormData),
@@ -87,19 +88,17 @@ cleanPlots <- function(objCOTAN, includePCA = TRUE) {
                        BSPARAM = IrlbaParam(),
                        get.rotation = FALSE)[["x"]]
 
-    logThis("Elaborating PCA - DONE", logLevel = 3L)
-
     assert_that(identical(rownames(cellsRDM), getCells(objCOTAN)),
                 msg = "Issues with pca output")
+
+    logThis("PCA: DONE", logLevel = 2L)
+
+    logThis("Hierarchical clustering: START", logLevel = 2L)
 
     distCells <- scale(cellsRDM)
     distCells <- calcDist(distCells, method = "euclidean") # mahlanobis
 
     cellsRDM <- as.data.frame(cellsRDM)
-
-    logThis("PCA: DONE", logLevel = 2L)
-
-    logThis("Hierarchical clustering: START", logLevel = 2L)
 
     # hclust cannot operate on more than 2^16 elements
     if (getNumCells(objCOTAN) <= 65500L) {
@@ -246,6 +245,14 @@ cleanPlots <- function(objCOTAN, includePCA = TRUE) {
                                        " should probably be removed"),
                         color = "darkred", size = 4.5)
   }
+
+  endTime <- Sys.time()
+
+  logThis(paste("Total calculations elapsed time:",
+                difftime(endTime, startTime, units = "secs")),
+          logLevel = 2L)
+
+  logThis("Clean plots: DONE", logLevel = 2L)
 
   return(list("pcaCells" = cellsRDMPlot, "pcaCellsData" = cellsRDM,
               "genes" = genesPlot, "UDE" = UDEPlot,

--- a/R/data.R
+++ b/R/data.R
@@ -154,7 +154,7 @@ NULL
 #'   only some specific versions of `cuda` (and corresponding `cudnn`) are
 #'   effectively usable, so one needs to install them to actually use the `GPU`.
 #'
-#'   As of today only `cuda` 11.7 and 11.8 are supported, but check the `torch`
+#'   As of today only `cuda` 12.4 is supported, but check the `torch`
 #'   documentation for more up-to-date information. Before downgrading your
 #'   `cuda` version, please be aware that it is possible to maintain separate
 #'   main versions of `cuda` at the same time on the system: that is one can
@@ -162,7 +162,7 @@ NULL
 #'
 #'   Below a link to install `cuda` 11.8 for `WSL2` given: use a local installer
 #'   to be sure the wanted `cuda` version is being installed, and not the latest
-#'   one: [`cuda` 11.8 for `WSL2`](https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local)
+#'   one: [`cuda` 12.4 for `WSL2`](https://developer.nvidia.com/cuda-12-4-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local)
 #'
 #' @name Installing_torch
 #'

--- a/R/data.R
+++ b/R/data.R
@@ -133,13 +133,16 @@ NULL
 
 # ---------- Torch library section ----------
 
-#' @title Installing torch R library (on Linux)
+#' @title Installing `torch` `R` library (on `WSL-Linux`)
 #'
 #' @description A brief explanation of how to install the torch package on
-#'   `WSL2` (Windows Subsystem for Linux), but it might work the same for other
-#'   `Linux` systems. Naturally it makes a difference whether one wants to
+#'   `WSL2` (`Windows Subsystem for Linux`), but it might work the same for
+#'   other `Linux` systems. Naturally it makes a difference whether one wants to
 #'   install support only for the `CPU` or also have the system `GPU` at the
 #'   ready!
+#'
+#'   This are just *suggestions*, no guarantees are given:
+#'   **try at your own peril!**
 #'
 #' @description The main resources to install `torch` is
 #'   \url{https://torch.mlverse.org/docs/articles/installation.html} or
@@ -154,16 +157,34 @@ NULL
 #'   only some specific versions of `cuda` (and corresponding `cudnn`) are
 #'   effectively usable, so one needs to install them to actually use the `GPU`.
 #'
-#'   As of today only `cuda` 12.4 is supported, but check the `torch`
+#'   As of today only `cuda` 12.8 is supported, but check the `torch`
 #'   documentation for more up-to-date information. Before downgrading your
 #'   `cuda` version, please be aware that it is possible to maintain separate
-#'   main versions of `cuda` at the same time on the system: that is one can
-#'   have installed both 11.8 and a 12.4 `cuda` versions on the same system.
+#'   main versions of `cuda` at the same time on the system.
 #'
-#'   Below a link to install `cuda` 11.8 for `WSL2` given: use a local installer
+#'   Below a link to install `cuda` 12.8 for `WSL2` given: use a local installer
 #'   to be sure the wanted `cuda` version is being installed, and not the latest
-#'   one: [`cuda` 12.4 for `WSL2`](https://developer.nvidia.com/cuda-12-4-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local)
+#'   one: [`cuda` 12.8 for `WSL2`](https://developer.nvidia.com/cuda-12-8-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local)
+#'
+#'   It can happen that after the installation of the new `torch` version,
+#'   including the dependencies, `torch` actually fails to run claiming that
+#'   `lantern` dependency was not installed.
+#'   This can happen due to presence of old cache files, so one can simply
+#'   delete the relevant cache folder as in the example below...
+#'
+#' @examplesIf FALSE
+#'   # find the relevant cache folder and delete it
+#'   folder <- tools::R_user_dir("torch","cache")
+#'   print(folder)
+#'   unlink(folder, recursive = TRUE, force = TRUE)
+#'
+#'   # reinstall explicitly for the toolchain you want
+#'   torch::install_torch(cuda_version = "12.8", reinstall = TRUE)
+#'
+#'   # run this only **AFTER** restarting `R`
+#'   COTAN:::canUseTorch(TRUE, "cuda")
 #'
 #' @name Installing_torch
 #'
 NULL
+

--- a/R/establishGenesClusters.R
+++ b/R/establishGenesClusters.R
@@ -56,7 +56,9 @@ NULL
 #'
 genesCoexSpace <-
   function(objCOTAN, primaryMarkers, numGenesPerMarker = 25L) {
-  logThis("Calculating gene co-expression space - START", logLevel = 2L)
+    startTime <- Sys.time()
+
+    logThis("Calculating gene co-expression space - START", logLevel = 2L)
 
   if (TRUE) {
     genesBelong <- primaryMarkers %in% getGenes(objCOTAN)
@@ -115,6 +117,12 @@ genesCoexSpace <-
   logThis(paste0("Number of columns (V set - secondary markers): ",
                  dim(GCS)[[2L]]), logLevel = 3L)
   logThis(paste0("Number of rows (U set): ", dim(GCS)[[1L]]), logLevel = 3L)
+
+  endTime <- Sys.time()
+
+  logThis(paste("Total calculations elapsed time:",
+                difftime(endTime, startTime, units = "secs")),
+          logLevel = 2L)
 
   logThis("Calculating gene co-expression space - DONE", logLevel = 2L)
 
@@ -179,6 +187,8 @@ genesCoexSpace <-
 establishGenesClusters <-
   function(objCOTAN, groupMarkers, numGenesPerMarker = 25L,
            kCuts = 6L, distance = "cosine", hclustMethod = "ward.D2") {
+  startTime <- Sys.time()
+
   logThis("Establishing gene clusters - START", logLevel = 2L)
 
   assert_that(!is.null(names(groupMarkers)),
@@ -303,6 +313,12 @@ establishGenesClusters <-
     dendextend::set("labels",
                     ifelse(labels(dend) %in% rownames(pca1)[relPos],
                            labels(dend), ""))
+
+  endTime <- Sys.time()
+
+  logThis(paste("Total calculations elapsed time:",
+                difftime(endTime, startTime, units = "secs")),
+          logLevel = 2L)
 
   logThis("Establishing gene clusters - DONE", logLevel = 2L)
 

--- a/R/findClustersMarkers.R
+++ b/R/findClustersMarkers.R
@@ -49,6 +49,8 @@ findClustersMarkers <- function(
     objCOTAN, n = 10L, markers = NULL,
     clName = "", clusters = NULL,
     coexDF = NULL, adjustmentMethod = "bonferroni") {
+  startTime <- Sys.time()
+
   logThis("findClustersMarkers - START", logLevel = 2L)
 
   marks <- unlist(markers)
@@ -103,6 +105,12 @@ findClustersMarkers <- function(
       rm(tmpDF)
     }
   }
+
+  endTime <- Sys.time()
+
+  logThis(paste("Total calculations elapsed time:",
+                difftime(endTime, startTime, units = "secs")),
+          logLevel = 2L)
 
   logThis("findClustersMarkers - DONE", logLevel = 2L)
 

--- a/R/genesStatistics.R
+++ b/R/genesStatistics.R
@@ -79,7 +79,7 @@ runGDICalc <- function(genesBatches, S, topRows, cores) {
                               S = S,
                               topRows = topRows,
                               mc.cores  = cores,
-                              mc.preschedule = FALSE)
+                              mc.preschedule = TRUE)
 
     # spawned errors are stored as try-error classes
     resError <- unlist(lapply(res, inherits, "try-error"))

--- a/R/genesStatistics.R
+++ b/R/genesStatistics.R
@@ -129,11 +129,13 @@ calculateGDIGivenS  <- function(S,
                                 rowsFraction = 0.05,
                                 cores        = 1L,
                                 chunkSize    = 1024L) {
+  startTime <- Sys.time()
+
+  logThis("Calculate `GDI`: START", logLevel = 2L)
+
   # Beware S might not be square!
   assertthat::assert_that(length(dim(S)) == 2L,
                           rowsFraction > 0, rowsFraction <= 1)
-
-  logThis("Calculate `GDI`: START", logLevel = 2L)
 
   cores <- handleMultiCore(cores)
 
@@ -160,6 +162,12 @@ calculateGDIGivenS  <- function(S,
   GDI <- unlist(gdiList, use.names = FALSE, recursive = TRUE)
 
   names(GDI) <- genes
+
+  endTime <- Sys.time()
+
+  logThis(paste("Total calculations elapsed time:",
+                difftime(endTime, startTime, units = "secs")),
+          logLevel = 2L)
 
   logThis("Calculate `GDI`: DONE", logLevel = 2L)
 
@@ -227,6 +235,8 @@ calculateGDI <- function(objCOTAN,
                          rowsFraction = 0.05,
                          cores        = 1L,
                          chunkSize    = 1024L) {
+  startTime <- Sys.time()
+
   logThis("Calculate GDI dataframe: START", logLevel = 2L)
 
   if (statType == "S") {
@@ -259,6 +269,12 @@ calculateGDI <- function(objCOTAN,
   gc()
 
   GDI <- GDI[, c("sum.raw.norm", "GDI", "exp.cells")]
+
+  endTime <- Sys.time()
+
+  logThis(paste("Total calculations elapsed time:",
+                difftime(endTime, startTime, units = "secs")),
+          logLevel = 2L)
 
   logThis("Calculate GDI dataframe: DONE", logLevel = 2L)
 
@@ -294,6 +310,8 @@ calculateGDI <- function(objCOTAN,
 calculatePValue <- function(objCOTAN, statType = "S",
                             geneSubsetCol = vector(mode = "character"),
                             geneSubsetRow = vector(mode = "character")) {
+  startTime <- Sys.time()
+
   geneSubsetCol <- handleNamesSubsets(getGenes(objCOTAN), geneSubsetCol)
   geneSubsetRow <- handleNamesSubsets(getGenes(objCOTAN), geneSubsetRow)
 
@@ -326,6 +344,12 @@ calculatePValue <- function(objCOTAN, statType = "S",
   if (allCols && allRows) {
     pValues <- pack(forceSymmetric(pValues))
   }
+
+  endTime <- Sys.time()
+
+  logThis(paste("Total calculations elapsed time:",
+                difftime(endTime, startTime, units = "secs")),
+          logLevel = 2L)
 
   logThis("calculating PValues: DONE", logLevel = 2L)
 

--- a/R/heatmap-plot.R
+++ b/R/heatmap-plot.R
@@ -185,7 +185,9 @@ heatmapPlot <- function(objCOTAN = NULL,
                         pValueThreshold = 0.01,
                         conditions = NULL,
                         dir = ".") {
-  logThis("heatmap plot: START", logLevel = 2L)
+  startTime <- Sys.time()
+
+  logThis("Heatmap plot: START", logLevel = 2L)
 
   assert_that(is.null(objCOTAN) != is_empty(conditions),
               msg = paste("Please pass either a COTAN object",
@@ -242,6 +244,14 @@ heatmapPlot <- function(objCOTAN = NULL,
                                   guide = "colourbar", aesthetics = "fill",
                                   oob = squish) +
              plotTheme("heatmap", textSize = 9L)
+
+  endTime <- Sys.time()
+
+  logThis(paste("Total calculations elapsed time:",
+                difftime(endTime, startTime, units = "secs")),
+          logLevel = 2L)
+
+  logThis("Heatmap plot: DONE", logLevel = 2L)
 
   return(heatmap)
 }

--- a/R/mergeUniformCellsClusters.R
+++ b/R/mergeUniformCellsClusters.R
@@ -372,6 +372,8 @@ mergeUniformCellsClusters <- function(objCOTAN,
 
   # start analysis
 
+  startTime <- Sys.time()
+
   logThis("Merging cells' uniform clustering: START", logLevel = 2L)
 
   assert_that(estimatorsAreReady(objCOTAN),
@@ -451,6 +453,8 @@ mergeUniformCellsClusters <- function(objCOTAN,
                    getCheckerThreshold(checker)),
             logLevel = 2L)
     repeat {
+      startLoopTime <- Sys.time()
+
       iter <- iter + 1L
       logThis(paste0("Start merging nearest clusters: iteration ", iter),
               logLevel = 3L)
@@ -539,6 +543,12 @@ mergeUniformCellsClusters <- function(objCOTAN,
         logThis(paste("Executed", (oldNumClusters - newNumClusters), "merges"),
                 logLevel = 3L)
       }
+
+      endLoopTime <- Sys.time()
+
+      logThis(paste("Loop calculations elapsed time:",
+                    difftime(endLoopTime, startLoopTime, units = "secs")),
+              logLevel = 2L)
     }
     logThis(paste0("Executed all merges for threshold ",
                    getCheckerThreshold(checker), " out of ",
@@ -595,6 +605,12 @@ mergeUniformCellsClusters <- function(objCOTAN,
     write.csv(as.data.frame(list("merge" = outputClusters)),
               file = outFile, na = "NaN")
   })
+
+  endTime <- Sys.time()
+
+  logThis(paste("Total calculations elapsed time:",
+                difftime(endTime, startTime, units = "secs")),
+          logLevel = 2L)
 
   logThis("Merging cells' uniform clustering: DONE", logLevel = 2L)
 

--- a/man/COTAN_ObjectCreation.Rd
+++ b/man/COTAN_ObjectCreation.Rd
@@ -20,7 +20,7 @@ COTAN(raw = "ANY")
   genesCutoff = 0.002,
   cellsThreshold = 0.99,
   genesThreshold = 0.99,
-  saveObj = TRUE,
+  saveObj = FALSE,
   outDir = "."
 )
 
@@ -37,7 +37,7 @@ automaticCOTANObjectCreation(
   genesCutoff = 0.002,
   cellsThreshold = 0.99,
   genesThreshold = 0.99,
-  saveObj = TRUE,
+  saveObj = FALSE,
   outDir = "."
 )
 }

--- a/man/Installing_torch.Rd
+++ b/man/Installing_torch.Rd
@@ -24,7 +24,7 @@ For the \code{GPU}, currently only \code{cuda} devices are supported. Moreover
 only some specific versions of \code{cuda} (and corresponding \code{cudnn}) are
 effectively usable, so one needs to install them to actually use the \code{GPU}.
 
-As of today only \code{cuda} 11.7 and 11.8 are supported, but check the \code{torch}
+As of today only \code{cuda} 12.4 is supported, but check the \code{torch}
 documentation for more up-to-date information. Before downgrading your
 \code{cuda} version, please be aware that it is possible to maintain separate
 main versions of \code{cuda} at the same time on the system: that is one can
@@ -32,5 +32,5 @@ have installed both 11.8 and a 12.4 \code{cuda} versions on the same system.
 
 Below a link to install \code{cuda} 11.8 for \code{WSL2} given: use a local installer
 to be sure the wanted \code{cuda} version is being installed, and not the latest
-one: \href{https://developer.nvidia.com/cuda-11-8-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local}{\code{cuda} 11.8 for \code{WSL2}}
+one: \href{https://developer.nvidia.com/cuda-12-4-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local}{\code{cuda} 12.4 for \code{WSL2}}
 }

--- a/man/Installing_torch.Rd
+++ b/man/Installing_torch.Rd
@@ -2,13 +2,16 @@
 % Please edit documentation in R/data.R
 \name{Installing_torch}
 \alias{Installing_torch}
-\title{Installing torch R library (on Linux)}
+\title{Installing \code{torch} \code{R} library (on \code{WSL-Linux})}
 \description{
 A brief explanation of how to install the torch package on
-\code{WSL2} (Windows Subsystem for Linux), but it might work the same for other
-\code{Linux} systems. Naturally it makes a difference whether one wants to
+\code{WSL2} (\verb{Windows Subsystem for Linux}), but it might work the same for
+other \code{Linux} systems. Naturally it makes a difference whether one wants to
 install support only for the \code{CPU} or also have the system \code{GPU} at the
 ready!
+
+This are just \emph{suggestions}, no guarantees are given:
+\strong{try at your own peril!}
 
 The main resources to install \code{torch} is
 \url{https://torch.mlverse.org/docs/articles/installation.html} or
@@ -24,13 +27,32 @@ For the \code{GPU}, currently only \code{cuda} devices are supported. Moreover
 only some specific versions of \code{cuda} (and corresponding \code{cudnn}) are
 effectively usable, so one needs to install them to actually use the \code{GPU}.
 
-As of today only \code{cuda} 12.4 is supported, but check the \code{torch}
+As of today only \code{cuda} 12.8 is supported, but check the \code{torch}
 documentation for more up-to-date information. Before downgrading your
 \code{cuda} version, please be aware that it is possible to maintain separate
-main versions of \code{cuda} at the same time on the system: that is one can
-have installed both 11.8 and a 12.4 \code{cuda} versions on the same system.
+main versions of \code{cuda} at the same time on the system.
 
-Below a link to install \code{cuda} 11.8 for \code{WSL2} given: use a local installer
+Below a link to install \code{cuda} 12.8 for \code{WSL2} given: use a local installer
 to be sure the wanted \code{cuda} version is being installed, and not the latest
-one: \href{https://developer.nvidia.com/cuda-12-4-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local}{\code{cuda} 12.4 for \code{WSL2}}
+one: \href{https://developer.nvidia.com/cuda-12-8-0-download-archive?target_os=Linux&target_arch=x86_64&Distribution=WSL-Ubuntu&target_version=2.0&target_type=deb_local}{\code{cuda} 12.8 for \code{WSL2}}
+
+It can happen that after the installation of the new \code{torch} version,
+including the dependencies, \code{torch} actually fails to run claiming that
+\code{lantern} dependency was not installed.
+This can happen due to presence of old cache files, so one can simply
+delete the relevant cache folder as in the example below...
+}
+\examples{
+\dontshow{if (FALSE) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
+  # find the relevant cache folder and delete it
+  folder <- tools::R_user_dir("torch","cache")
+  print(folder)
+  unlink(folder, recursive = TRUE, force = TRUE)
+
+  # reinstall explicitly for the toolchain you want
+  torch::install_torch(cuda_version = "12.8", reinstall = TRUE)
+
+  # run this only **AFTER** restarting `R`
+  COTAN:::canUseTorch(TRUE, "cuda")
+\dontshow{\}) # examplesIf}
 }

--- a/tests/testthat/test-calculateCoex-method.R
+++ b/tests/testthat/test-calculateCoex-method.R
@@ -529,7 +529,7 @@ test_that("Coex with negative dispersion genes", {
   coex3 <- getGenesCoex(obj, zeroDiagonal = FALSE)
 
   expect_equal(coex1, coex2, tolerance = 1e-7)
-  expect_equal(coex1, coex3, tolerance = 1e-7)
+  expect_equal(coex1, coex3, tolerance = 2e-7)
   expect_equal(coex2, coex3, tolerance = 5e-7)
 
   groupMarkers <- list(G1 = c("g-000010", "g-000020", "g-000030"),


### PR DESCRIPTION
Improved torch `coex` implementation:
- Used more in-place functions
- Avoided use of 2 copies of the entire probability matrix to calculate the probability of zero

Also switched back to `mc.preschedule = TRUE` in all `mclapply()` calls as all sub-tasks take roughly the same amount of time

Added more logging about timings in more numerical intensive functions